### PR TITLE
Support for `package` access level

### DIFF
--- a/Sources/MemberwiseInit/MemberwiseInit.swift
+++ b/Sources/MemberwiseInit/MemberwiseInit.swift
@@ -2,6 +2,7 @@ public enum AccessLevelConfig {
   case `private`
   case `fileprivate`
   case `internal`
+  case `package`
   case `public`
   case `open`
 }

--- a/Sources/MemberwiseInitMacros/Macros/MemberwiseInitMacro.swift
+++ b/Sources/MemberwiseInitMacros/Macros/MemberwiseInitMacro.swift
@@ -310,7 +310,7 @@ public struct MemberwiseInitMacro: MemberMacro {
     return switch initAccessLevel {
     case .private, .fileprivate, .internal:
       true
-    case .public, .open:
+    case .package, .public, .open:
       false
     }
   }

--- a/Sources/MemberwiseInitMacros/Macros/Support/AccesssLevelSyntax.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/AccesssLevelSyntax.swift
@@ -17,6 +17,7 @@ enum AccessLevelModifier: String, Comparable, CaseIterable, Sendable {
   case `private`
   case `fileprivate`
   case `internal`
+  case `package`
   case `public`
   case `open`
 
@@ -25,6 +26,7 @@ enum AccessLevelModifier: String, Comparable, CaseIterable, Sendable {
     case .private: return .private
     case .fileprivate: return .fileprivate
     case .internal: return .internal
+    case .package: return .package
     case .public: return .public
     case .open: return .open
     }

--- a/Tests/MemberwiseInitTests/MemberwiseInitTests.swift
+++ b/Tests/MemberwiseInitTests/MemberwiseInitTests.swift
@@ -886,6 +886,10 @@ final class MemberwiseInitTests: XCTestCase {
       }
 
       @MemberwiseInit
+      package struct Person {
+      }
+
+      @MemberwiseInit
       public struct Person {
       }
 
@@ -915,6 +919,11 @@ final class MemberwiseInitTests: XCTestCase {
           internal init() {
           }
       }
+      package struct Person {
+
+          internal init() {
+          }
+      }
       public struct Person {
 
           internal init() {
@@ -929,9 +938,9 @@ final class MemberwiseInitTests: XCTestCase {
     }
   }
 
-  // NB: This is almost covered by the exhaustive AccessLevelTests, but `open class Person`
-  // is missing. This test touches on all the access levels (instead of a meaningful few).
-  func testDefaultInitAccessLeves() {
+  // NB: This is almost covered by the exhaustive AccessLevelTests. This test touches on all the
+  // access levels (instead of a meaningful few).
+  func testDefaultInitAccessLevels() {
     assertMacro {
       """
       @MemberwiseInit
@@ -952,6 +961,11 @@ final class MemberwiseInitTests: XCTestCase {
       @MemberwiseInit
       internal struct Person {
         fileprivate let name: String
+      }
+
+      @MemberwiseInit
+      package struct Person {
+        let name: String
       }
 
       @MemberwiseInit
@@ -997,6 +1011,15 @@ final class MemberwiseInitTests: XCTestCase {
         fileprivate let name: String
 
         fileprivate init(
+          name: String
+        ) {
+          self.name = name
+        }
+      }
+      package struct Person {
+        let name: String
+
+        internal init(
           name: String
         ) {
           self.name = name
@@ -1047,6 +1070,29 @@ final class MemberwiseInitTests: XCTestCase {
         ) {
           self.firstName = firstName
           self.lastName = lastName
+        }
+      }
+      """
+    }
+  }
+
+  func testMemberwiseInitPackage_PublicStruct_PublicProperty_PackageInit() throws {
+    assertMacro {
+      """
+      @MemberwiseInit(.package)
+      public struct Person {
+        public let firstName: String
+      }
+      """
+    } expansion: {
+      """
+      public struct Person {
+        public let firstName: String
+
+        package init(
+          firstName: String
+        ) {
+          self.firstName = firstName
         }
       }
       """
@@ -1846,6 +1892,29 @@ final class MemberwiseInitTests: XCTestCase {
 
         internal init(
           nickname: String? = nil
+        ) {
+          self.nickname = nickname
+        }
+      }
+      """
+    }
+  }
+
+  func testOptionalVarProperty_PackageInitNoDefault() {
+    assertMacro {
+      """
+      @MemberwiseInit(.public)
+      public struct Person {
+        package var nickname: String?
+      }
+      """
+    } expansion: {
+      """
+      public struct Person {
+        package var nickname: String?
+
+        package init(
+          nickname: String?
         ) {
           self.nickname = nickname
         }


### PR DESCRIPTION
Fixes #6.

This builds upon the work done in PR #5 by David Roman, with the following changes:

* Don't default to `optionalsDefaultNil` for `package` access level
* Add tests