### PR TITLE
Add `@Init(assignee:type:)` to (awkwardly) support property wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Informed by explicit developer cues, MemberwiseInit can more often automatically
   * [Infer type from property initialization expressions](#infer-type-from-property-initialization-expressions)
   * [Explicitly ignore properties](#explicitly-ignore-properties)
   * [Attributed properties are ignored by default, but includable](#attributed-properties-are-ignored-by-default-but-includable)
+  * [Support for property wrappers](#support-for-property-wrappers)
   * [Automatic `@escaping` for closure types (usually)](#automatic-escaping-for-closure-types-usually)
   * [Experimental: Deunderscore parameter names](#experimental-deunderscore-parameter-names)
   * [Experimental: Defaulting optionals to nil](#experimental-defaulting-optionals-to-nil)
@@ -99,7 +100,7 @@ To use MemberwiseInit:
 
 ## Quick reference
 
-MemberwiseInit includes two autocomplete-friendly macros:
+MemberwiseInit includes two macros:
 
 ### `@MemberwiseInit`
 
@@ -144,6 +145,20 @@ Attach to member property declarations of a struct, actor, or class that `@Membe
 
 * `@Init(.public, label: String)`
   <br> Custom labels can be combined with all other behaviors.
+
+* `@Init(assignee: String)`
+  <br> Override the target property to which the initializer argument should be assigned. By default, a property named “property” has the assignee `self.property`, as demonstrated in `self.property = property`.
+
+* `@Init(type: Any.Type)`
+  <br> Override the type of the argument in the initializer.
+
+* `@Init(assignee: String, type: Any.Type)`
+  <br> Combine `assignee` and `type` to support usage with property wrappers:
+
+  ```swift
+  @Init(assignee: "self._isOn", type: Binding<Bool>)
+  @Binding var isOn = true
+  ```
 
 ## Features and limitations
 
@@ -380,6 +395,22 @@ From here, you have two alternatives:
      self.isOn = isOn
    }
    ```
+
+### Support for property wrappers
+
+Combine `@Init(assignee:)` and `@Init(type)` to support property wrappers. For example, here’s a simple usage with SwiftUI’s `@Binding`:
+
+```swift
+import SwiftUI
+
+@MemberwiseInit
+struct CounterView: View {
+  @Init(assignee: “self._count”, type: Binding<Int>)
+  @Binding var count = 0
+
+  var body: some View { … }
+}
+```
 
 ### Automatic `@escaping` for closure types (usually)
 

--- a/Sources/MemberwiseInit/MemberwiseInit.swift
+++ b/Sources/MemberwiseInit/MemberwiseInit.swift
@@ -11,8 +11,8 @@ public enum AccessLevelConfig {
 
 @attached(member, names: named(init))
 public macro MemberwiseInit(
-  _ accessLevel: AccessLevelConfig = .internal,
-  _deunderscoreParameters: Bool = false,
+  _ accessLevel: AccessLevelConfig? = nil,
+  _deunderscoreParameters: Bool? = nil,
   _optionalsDefaultNil: Bool? = nil
 ) =
   #externalMacro(
@@ -31,7 +31,13 @@ public enum IgnoreConfig {
 }
 
 @attached(peer)
-public macro Init() =
+public macro Init(
+  _ accessLevel: AccessLevelConfig? = nil,
+  assignee: String? = nil,
+  escaping: Bool? = nil,
+  label: String? = nil,
+  type: Any.Type? = nil
+) =
   #externalMacro(
     module: "MemberwiseInitMacros",
     type: "InitMacro"
@@ -46,15 +52,9 @@ public macro Init(
     type: "InitMacro"
   )
 
-@attached(peer)
-public macro Init(
-  label: String
-) =
-  #externalMacro(
-    module: "MemberwiseInitMacros",
-    type: "InitMacro"
-  )
+// MARK: - Deprecated
 
+// Deprecated; remove in 1.0
 @attached(peer)
 public macro Init(
   _ accessLevel: AccessLevelConfig,
@@ -66,16 +66,7 @@ public macro Init(
     type: "InitMacro"
   )
 
-@attached(peer)
-public macro Init(
-  _ accessLevel: AccessLevelConfig,
-  label: String? = nil
-) =
-  #externalMacro(
-    module: "MemberwiseInitMacros",
-    type: "InitMacro"
-  )
-
+// Deprecated; remove in 1.0
 @attached(peer)
 public macro Init(
   _ escaping: EscapingConfig,

--- a/Sources/MemberwiseInitMacros/Macros/Support/SyntaxHelpers.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/SyntaxHelpers.swift
@@ -59,3 +59,12 @@ extension PatternSyntax {
     self.as(TuplePatternSyntax.self) != nil
   }
 }
+
+extension ExprSyntax {
+  var trimmedStringLiteral: String? {
+    self.as(StringLiteralExprSyntax.self)?
+      .segments
+      .trimmedDescription
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+}

--- a/Tests/MemberwiseInitTests/MemberwiseInitTests.swift
+++ b/Tests/MemberwiseInitTests/MemberwiseInitTests.swift
@@ -20,6 +20,101 @@ final class MemberwiseInitTests: XCTestCase {
     }
   }
 
+  // MARK: - Test custom type
+
+  func testCustomType() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(type: Q) var type: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        var type: T
+
+        internal init(
+          type: Q
+        ) {
+          self.type = type
+        }
+      }
+      """
+    }
+  }
+
+  func testCustomType_GenericExpression() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(type: Q<R>) var type: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        var type: T
+
+        internal init(
+          type: Q<R>
+        ) {
+          self.type = type
+        }
+      }
+      """
+    }
+  }
+
+  // TODO: Add fix-it diagnostic when provided type is a Metatype
+  //  func testCustomType_MetatypeFailsWithDiagnostic() {
+  //    assertMacro(record: true) {
+  //      """
+  //      @MemberwiseInit
+  //      struct S {
+  //        @Init(type: Q.self) var type: T
+  //      }
+  //      """
+  //    } diagnostics: {
+  //      """
+  //      @MemberwiseInit
+  //      struct S {
+  //        @Init(type: Q.self) var type: T
+  //            ┬─────────────────
+  //            ╰─ 🛑 Invalid use of metatype 'Q.self'. Expected a type, not its metatype.
+  //            ╰─ 🛑 Remove '.self'; type is expected, not a metatype.
+  //      }
+  //      """
+  //    }
+  //  }
+
+  // MARK: - Test custom assign
+
+  func testCustomAssign() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(assignee: "self._type") var type: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        var type: T
+
+        internal init(
+          type: T
+        ) {
+          self._type = type
+        }
+      }
+      """
+    }
+  }
+
   // MARK: - Test simple usage
 
   // NB: Redundant to AccessLevelTests but handy to have here, too.


### PR DESCRIPTION
Resolves #11.