### PR TITLE
Provide init at the requested access level or fail

### DIFF
--- a/Sources/MemberwiseInitMacros/Macros/Support/CustomConfiguration.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/CustomConfiguration.swift
@@ -1,0 +1,19 @@
+import SwiftSyntax
+
+extension VariableDeclSyntax {
+  var customConfiguration: LabeledExprListSyntax? {
+    self.attributes
+      .first(where: {
+        $0.as(AttributeSyntax.self)?.attributeName.trimmedDescription == "Init"
+      })?
+      .as(AttributeSyntax.self)?
+      .arguments?
+      .as(LabeledExprListSyntax.self)
+  }
+}
+
+extension LabeledExprListSyntax {
+  func firstWhereLabel(_ label: String) -> Element? {
+    first(where: { $0.label?.text == label })
+  }
+}

--- a/Sources/MemberwiseInitMacros/Macros/Support/Diagnostics.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/Diagnostics.swift
@@ -2,6 +2,7 @@ import SwiftDiagnostics
 import SwiftSyntax
 
 enum MemberwiseInitMacroDiagnostic: Error, DiagnosticMessage {
+  case labelAppliedToMultipleBindings
   case labelConflictsWithProperty(String)
   case labelConflictsWithAnotherLabel(String)
   case invalidDeclarationKind(DeclGroupSyntax)
@@ -11,6 +12,9 @@ enum MemberwiseInitMacroDiagnostic: Error, DiagnosticMessage {
 
   private var rawValue: String {
     switch self {
+    case .labelAppliedToMultipleBindings:
+      ".labelAppliedToMultipleBindings"
+
     case .invalidDeclarationKind(let declGroup):
       ".invalidDeclarationKind(\(declGroup.kind))"
 
@@ -35,6 +39,11 @@ enum MemberwiseInitMacroDiagnostic: Error, DiagnosticMessage {
 
   var message: String {
     switch self {
+    case .labelAppliedToMultipleBindings:
+      return """
+        Custom 'label' can't be applied to multiple bindings
+        """
+
     case let .invalidDeclarationKind(declGroup):
       return """
         @MemberwiseInit can only be attached to a struct, class, or actor; \

--- a/Sources/MemberwiseInitMacros/Macros/Support/SyntaxHelpers.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/SyntaxHelpers.swift
@@ -60,6 +60,13 @@ extension PatternSyntax {
   }
 }
 
+extension VariableDeclSyntax {
+  var isFullyInitializedLet: Bool {
+    self.bindingSpecifier.tokenKind == .keyword(.let)
+      && self.bindings.allSatisfy { $0.initializer != nil }
+  }
+}
+
 extension ExprSyntax {
   var trimmedStringLiteral: String? {
     self.as(StringLiteralExprSyntax.self)?

--- a/Tests/MemberwiseInitTests/MemberwiseInitAccessLevelTests.swift
+++ b/Tests/MemberwiseInitTests/MemberwiseInitAccessLevelTests.swift
@@ -911,16 +911,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         private let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit
       private struct S {
         private let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        ┬──────
+        ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
       }
       """
     }
@@ -934,16 +931,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) private let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit
       private struct S {
-        private let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.private) private let v: T
+              ┬───────
+              ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
       }
       """
     }
@@ -1003,16 +997,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit
       private struct S {
         let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        ┬───────
+        ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
       }
       """
     }
@@ -1026,16 +1017,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit
       private struct S {
-        let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.private) let v: T
+              ┬───────
+              ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
       }
       """
     }
@@ -1118,16 +1106,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) public let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit
       private struct S {
-        public let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.private) public let v: T
+              ┬───────
+              ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
       }
       """
     }
@@ -1205,16 +1190,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         private let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit
       struct S {
         private let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        ┬──────
+        ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
       }
       """
     }
@@ -1228,16 +1210,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) private let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit
       struct S {
-        private let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.private) private let v: T
+              ┬───────
+              ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
       }
       """
     }
@@ -1320,16 +1299,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit
       struct S {
-        let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.private) let v: T
+              ┬───────
+              ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
       }
       """
     }
@@ -1412,16 +1388,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) public let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit
       struct S {
-        public let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.private) public let v: T
+              ┬───────
+              ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
       }
       """
     }
@@ -1499,16 +1472,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         private let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit
       public struct S {
         private let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        ┬──────
+        ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
       }
       """
     }
@@ -1522,16 +1492,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) private let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit
       public struct S {
-        private let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.private) private let v: T
+              ┬───────
+              ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
       }
       """
     }
@@ -1614,16 +1581,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit
       public struct S {
-        let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.private) let v: T
+              ┬───────
+              ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
       }
       """
     }
@@ -1706,16 +1670,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) public let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit
       public struct S {
-        public let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.private) public let v: T
+              ┬───────
+              ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
       }
       """
     }
@@ -1793,16 +1754,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         private let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       private struct S {
         private let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        ┬──────
+        ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
       }
       """
     }
@@ -1816,16 +1774,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) private let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       private struct S {
-        private let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.private) private let v: T
+              ┬───────
+              ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
       }
       """
     }
@@ -1839,16 +1794,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.internal) private let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       private struct S {
-        private let v: T
-
-        internal init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.internal) private let v: T
+              ┬────────
+              ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
       }
       """
     }
@@ -1885,16 +1837,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       private struct S {
         let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        ┬───────
+        ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
       }
       """
     }
@@ -1908,16 +1857,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       private struct S {
-        let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.private) let v: T
+              ┬───────
+              ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
       }
       """
     }
@@ -1931,16 +1877,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.internal) let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       private struct S {
-        let v: T
-
-        internal init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.internal) let v: T
+              ┬────────
+              ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
       }
       """
     }
@@ -2000,16 +1943,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) public let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       private struct S {
-        public let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.private) public let v: T
+              ┬───────
+              ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
       }
       """
     }
@@ -2023,16 +1963,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.internal) public let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       private struct S {
-        public let v: T
-
-        internal init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.internal) public let v: T
+              ┬────────
+              ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
       }
       """
     }
@@ -2087,16 +2024,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         private let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       struct S {
         private let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        ┬──────
+        ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
       }
       """
     }
@@ -2110,16 +2044,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) private let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       struct S {
-        private let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.private) private let v: T
+              ┬───────
+              ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
       }
       """
     }
@@ -2133,16 +2064,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.internal) private let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       struct S {
-        private let v: T
-
-        internal init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.internal) private let v: T
+              ┬────────
+              ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
       }
       """
     }
@@ -2179,16 +2107,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       struct S {
         let v: T
-
-        internal init(
-          v: T
-        ) {
-          self.v = v
-        }
+        ┬───────
+        ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
       }
       """
     }
@@ -2202,16 +2127,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       struct S {
-        let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.private) let v: T
+              ┬───────
+              ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
       }
       """
     }
@@ -2225,16 +2147,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.internal) let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       struct S {
-        let v: T
-
-        internal init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.internal) let v: T
+              ┬────────
+              ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
       }
       """
     }
@@ -2294,16 +2213,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) public let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       struct S {
-        public let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.private) public let v: T
+              ┬───────
+              ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
       }
       """
     }
@@ -2317,16 +2233,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.internal) public let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       struct S {
-        public let v: T
-
-        internal init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.internal) public let v: T
+              ┬────────
+              ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
       }
       """
     }
@@ -2381,16 +2294,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         private let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       public struct S {
         private let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        ┬──────
+        ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
       }
       """
     }
@@ -2404,16 +2314,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) private let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       public struct S {
-        private let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.private) private let v: T
+              ┬───────
+              ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
       }
       """
     }
@@ -2427,16 +2334,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.internal) private let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       public struct S {
-        private let v: T
-
-        internal init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.internal) private let v: T
+              ┬────────
+              ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
       }
       """
     }
@@ -2473,16 +2377,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       public struct S {
         let v: T
-
-        internal init(
-          v: T
-        ) {
-          self.v = v
-        }
+        ┬───────
+        ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
       }
       """
     }
@@ -2496,16 +2397,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       public struct S {
-        let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.private) let v: T
+              ┬───────
+              ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
       }
       """
     }
@@ -2519,16 +2417,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.internal) let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       public struct S {
-        let v: T
-
-        internal init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.internal) let v: T
+              ┬────────
+              ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
       }
       """
     }
@@ -2588,16 +2483,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) public let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       public struct S {
-        public let v: T
-
-        private init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.private) public let v: T
+              ┬───────
+              ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
       }
       """
     }
@@ -2611,16 +2503,13 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.internal) public let v: T
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       public struct S {
-        public let v: T
-
-        internal init(
-          v: T
-        ) {
-          self.v = v
-        }
+        @Init(.internal) public let v: T
+              ┬────────
+              ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
       }
       """
     }

--- a/Tests/MemberwiseInitTests/MemberwiseInitTests.swift
+++ b/Tests/MemberwiseInitTests/MemberwiseInitTests.swift
@@ -1035,7 +1035,7 @@ final class MemberwiseInitTests: XCTestCase {
 
   // NB: This is almost covered by the exhaustive AccessLevelTests. This test touches on all the
   // access levels (instead of a meaningful few).
-  func testDefaultInitAccessLevels() {
+  func testDefaultInitAccessLevels_FailsWithDiagnotics() {
     assertMacro {
       """
       @MemberwiseInit
@@ -1057,7 +1057,43 @@ final class MemberwiseInitTests: XCTestCase {
       internal struct Person {
         fileprivate let name: String
       }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      private struct Person {
+        private let name: String
+        ┬──────
+        ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
+      }
 
+      @MemberwiseInit
+      fileprivate struct Person {
+        private let name: String
+        ┬──────
+        ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
+      }
+
+      @MemberwiseInit
+      struct Person {
+        fileprivate let name: String
+        ┬──────────
+        ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'fileprivate' property
+      }
+
+      @MemberwiseInit
+      internal struct Person {
+        fileprivate let name: String
+        ┬──────────
+        ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'fileprivate' property
+      }
+      """
+    }
+  }
+
+  func testDefaultInitAccessLevels() {
+    assertMacro {
+      """
       @MemberwiseInit
       package struct Person {
         let name: String
@@ -1075,42 +1111,6 @@ final class MemberwiseInitTests: XCTestCase {
       """
     } expansion: {
       """
-      private struct Person {
-        private let name: String
-
-        private init(
-          name: String
-        ) {
-          self.name = name
-        }
-      }
-      fileprivate struct Person {
-        private let name: String
-
-        private init(
-          name: String
-        ) {
-          self.name = name
-        }
-      }
-      struct Person {
-        fileprivate let name: String
-
-        fileprivate init(
-          name: String
-        ) {
-          self.name = name
-        }
-      }
-      internal struct Person {
-        fileprivate let name: String
-
-        fileprivate init(
-          name: String
-        ) {
-          self.name = name
-        }
-      }
       package struct Person {
         let name: String
 
@@ -1142,7 +1142,9 @@ final class MemberwiseInitTests: XCTestCase {
     }
   }
 
-  func testMemberwiseInitPublic_PublicStruct_PublicAndImplicitlyInternalProperties_InternalInit() {
+  func
+    testMemberwiseInitPublic_PublicStruct_PublicAndImplicitlyInternalProperties_FailsWithDiagnostic()
+  {
     assertMacro {
       """
       @MemberwiseInit(.public)
@@ -1151,19 +1153,14 @@ final class MemberwiseInitTests: XCTestCase {
         let lastName: String
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit(.public)
       public struct Person {
         public let firstName: String
         let lastName: String
-
-        internal init(
-          firstName: String,
-          lastName: String
-        ) {
-          self.firstName = firstName
-          self.lastName = lastName
-        }
+        ┬───────────────────
+        ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
       }
       """
     }
@@ -1192,7 +1189,7 @@ final class MemberwiseInitTests: XCTestCase {
     }
   }
 
-  func testPublicStruct_PublicAndFileprivateProperty_FileprivateInit() {
+  func testPublicStruct_PublicAndFileprivateProperty_FailsWithDiagnostic() {
     assertMacro {
       """
       @MemberwiseInit
@@ -1201,19 +1198,14 @@ final class MemberwiseInitTests: XCTestCase {
         fileprivate let lastName: String
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit
       public struct Person {
         public let firstName: String
         fileprivate let lastName: String
-
-        fileprivate init(
-          firstName: String,
-          lastName: String
-        ) {
-          self.firstName = firstName
-          self.lastName = lastName
-        }
+        ┬──────────
+        ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'fileprivate' property
       }
       """
     }
@@ -1228,25 +1220,20 @@ final class MemberwiseInitTests: XCTestCase {
         private let lastName: String
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit
       public struct Person {
         public let firstName: String
         private let lastName: String
-
-        private init(
-          firstName: String,
-          lastName: String
-        ) {
-          self.firstName = firstName
-          self.lastName = lastName
-        }
+        ┬──────
+        ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
       }
       """
     }
   }
 
-  func testImplicitlyInternalStructWithPublicAndPrivateProperty_PrivateInit() {
+  func testImplicitlyInternalStructWithPublicAndPrivateProperty_FailsWithDiagnostic() {
     assertMacro {
       """
       @MemberwiseInit
@@ -1255,29 +1242,104 @@ final class MemberwiseInitTests: XCTestCase {
         private let lastName: String
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit
       struct Person {
         public let firstName: String
         private let lastName: String
+        ┬──────
+        ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
+      }
+      """
+    }
+  }
 
-        private init(
-          firstName: String,
-          lastName: String
-        ) {
-          self.firstName = firstName
-          self.lastName = lastName
-        }
+  func testEmptyCustomInitOnImplicitlyInternalProperty_FailsWithDiagnosticOnVariable() {
+    assertMacro {
+      """
+      @MemberwiseInit(.public)
+      public struct S {
+        @Init let v: T
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit(.public)
+      public struct S {
+        @Init let v: T
+        ┬─────────────
+        ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+      }
+      """
+    }
+  }
+
+  func testEmptyCustomInitOnPrivateProperty_FailsWithDiagnosticOnPrivateModifier() {
+    assertMacro {
+      """
+      @MemberwiseInit(.public)
+      public struct S {
+        @Init private let v: T
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit(.public)
+      public struct S {
+        @Init private let v: T
+              ┬──────
+              ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
+      }
+      """
+    }
+  }
+
+  func testCustomInitPrivate_FailsWithDiagnosticOnCustomInitPrivate() {
+    assertMacro {
+      """
+      @MemberwiseInit(.public)
+      public struct S {
+        @Init(.private, label: "_") let v: T
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit(.public)
+      public struct S {
+        @Init(.private, label: "_") let v: T
+              ┬───────
+              ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
+      }
+      """
+    }
+  }
+
+  func testCustomInitLabel_FailsWithDiagnosticOnPrivateModifier() {
+    assertMacro {
+      """
+      @MemberwiseInit(.public)
+      public struct S {
+        @Init(label: "_") private let v: T
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit(.public)
+      public struct S {
+        @Init(label: "_") private let v: T
+                          ┬──────
+                          ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
       }
       """
     }
   }
 
   // NB: Swift's memberwise init has the same behavior.
-  func testPublicStructWithPreinitializedPrivateLet_InternalInit() {
+  func testPublicStructWithPreinitializedPrivateLet_PublicInit() {
     assertMacro {
       """
-      @MemberwiseInit
+      @MemberwiseInit(.public)
       public struct Person {
         private let lastName: String = ""
       }
@@ -1287,7 +1349,7 @@ final class MemberwiseInitTests: XCTestCase {
       public struct Person {
         private let lastName: String = ""
 
-        internal init() {
+        public init() {
         }
       }
       """
@@ -1332,10 +1394,10 @@ final class MemberwiseInitTests: XCTestCase {
     }
   }
 
-  func testPrivateSetProperty_IsIncludedPrivateInit() {
+  func testMemberwiseInitPrivate_PrivateSetProperty_IsIncludedPrivateInit() {
     assertMacro {
       """
-      @MemberwiseInit
+      @MemberwiseInit(.private)
       struct Pedometer {
         private(set) var stepsToday: Int
       }
@@ -1355,7 +1417,7 @@ final class MemberwiseInitTests: XCTestCase {
     }
   }
 
-  func testPublicGetPrivateSetProperty_IsIncludedPrivateInit() {
+  func testPublicGetPrivateSetProperty_FailsWithDiagnostic() {
     assertMacro {
       """
       @MemberwiseInit
@@ -1363,42 +1425,56 @@ final class MemberwiseInitTests: XCTestCase {
         public private(set) var stepsToday: Int
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit
       struct Pedometer {
         public private(set) var stepsToday: Int
-
-        private init(
-          stepsToday: Int
-        ) {
-          self.stepsToday = stepsToday
-        }
+        ┬──────────────────
+        ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
       }
       """
     }
   }
 
-  func testNonInternalDefaultAccess() {
+  func testMemberwiseInitPublic_PrivateVarWithInitializer_FailsWithDiagnostic() {
+    assertMacro {
+      """
+      @MemberwiseInit(.public)
+      struct Pedometer {
+        private var stepsToday: Int = 0
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit(.public)
+      struct Pedometer {
+        private var stepsToday: Int = 0
+        ┬──────
+        ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
+      }
+      """
+    }
+  }
+
+  func testNonInternalDefaultAccess_FailsWithDiagnostic() {
     assertMacro {
       """
       struct S {
-        @MemberwiseInit
+        @MemberwiseInit(.internal)
         private struct T {
           let v: Int
         }
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
       struct S {
+        @MemberwiseInit(.internal)
         private struct T {
           let v: Int
-
-          private init(
-            v: Int
-          ) {
-            self.v = v
-          }
+          ┬─────────
+          ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
         }
       }
       """
@@ -1428,6 +1504,51 @@ final class MemberwiseInitTests: XCTestCase {
           for callback: @escaping CompletionHandler
         ) {
           self.callback = callback
+        }
+      }
+      """
+    }
+  }
+
+  func testCustomLabelWithMultipleBindings_FailsWithDiagnostic() {
+    assertMacro {
+      """
+      @MemberwiseInit(.public)
+      public struct Person {
+        @Init(label: "with") public let firstName, lastName: String
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit(.public)
+      public struct Person {
+        @Init(label: "with") public let firstName, lastName: String
+              ┬────────────
+              ╰─ 🛑 Custom 'label' can't be applied to multiple bindings
+      }
+      """
+    }
+  }
+
+  func testLabellessCustomInitForMultipleBindings() {
+    assertMacro {
+      """
+      @MemberwiseInit(.public)
+      public struct Person {
+        @Init(label: "_") public let firstName, lastName: String
+      }
+      """
+    } expansion: {
+      """
+      public struct Person {
+        public let firstName, lastName: String
+
+        public init(
+          _ firstName: String,
+          _ lastName: String
+        ) {
+          self.firstName = firstName
+          self.lastName = lastName
         }
       }
       """
@@ -1766,8 +1887,8 @@ final class MemberwiseInitTests: XCTestCase {
       @MemberwiseInit
       struct Person {
         @Init(label: "1foo") let name: String
-              ┬────────────
-              ╰─ 🛑 Invalid label value
+                     ┬─────
+                     ╰─ 🛑 Invalid label value
       }
       """
     }
@@ -1789,7 +1910,7 @@ final class MemberwiseInitTests: XCTestCase {
       @MemberwiseInit
       struct Person {
         @Init(label: """
-              ╰─ 🛑 Invalid label value
+                     ╰─ 🛑 Invalid label value
           too
           long
         """) let name: String
@@ -1923,7 +2044,7 @@ final class MemberwiseInitTests: XCTestCase {
   func testOptionalLetProperty_InternalInitNoDefault() {
     assertMacro {
       """
-      @MemberwiseInit(.public)
+      @MemberwiseInit(.internal)
       public struct Person {
         let nickname: String?
       }
@@ -1973,14 +2094,14 @@ final class MemberwiseInitTests: XCTestCase {
   func testOptionalVarProperty_InternalInitWithDefault() {
     assertMacro {
       """
-      @MemberwiseInit(.public)
-      public struct Person {
+      @MemberwiseInit(.internal)
+      struct Person {
         var nickname: String?
       }
       """
     } expansion: {
       """
-      public struct Person {
+      struct Person {
         var nickname: String?
 
         internal init(
@@ -1996,7 +2117,7 @@ final class MemberwiseInitTests: XCTestCase {
   func testOptionalVarProperty_PackageInitNoDefault() {
     assertMacro {
       """
-      @MemberwiseInit(.public)
+      @MemberwiseInit(.package)
       public struct Person {
         package var nickname: String?
       }


### PR DESCRIPTION
`@MemberwiseInit` now creates initializers at the specified access level or fails if it cannot do so. This change sharpens the safety and clarity of the macro, providing developers with immediate and actionable diagnostics when the desired initialization level cannot be met due to access restrictions on properties.

Caveat: the diagnostics don't include fix-its (yet).

Developers can resolve errors by adjusting property access levels or by configuring individual properties with `@Init` attributes to match the desired initializer access level.

The PR reflects a change in the design philosophy behind `@MemberwiseInit`, moving it away from being a superset of Swift's default memberwise initializer towards a tool that enforces explicit developer intent with respect to access levels. This shift is grounded in the belief that predictable, explicit behavior aligns better with Swift's ethos of safe and intentional coding practices.

Resolves #10.