### PR TITLE
Deprecate `@Init(.escaping)` in favor of `@Init(escaping: true)`

### DIFF
--- a/Sources/MemberwiseInit/MemberwiseInit.swift
+++ b/Sources/MemberwiseInit/MemberwiseInit.swift
@@ -11,7 +11,17 @@ public enum AccessLevelConfig {
 
 @attached(member, names: named(init))
 public macro MemberwiseInit(
-  _ accessLevel: AccessLevelConfig? = nil,
+  _ accessLevel: AccessLevelConfig,
+  _deunderscoreParameters: Bool? = nil,
+  _optionalsDefaultNil: Bool? = nil
+) =
+  #externalMacro(
+    module: "MemberwiseInitMacros",
+    type: "MemberwiseInitMacro"
+  )
+
+@attached(member, names: named(init))
+public macro MemberwiseInit(
   _deunderscoreParameters: Bool? = nil,
   _optionalsDefaultNil: Bool? = nil
 ) =
@@ -21,10 +31,6 @@ public macro MemberwiseInit(
   )
 
 // MARK: @Init macro
-
-public enum EscapingConfig {
-  case escaping
-}
 
 public enum IgnoreConfig {
   case ignore
@@ -55,6 +61,8 @@ public macro Init(
 // MARK: - Deprecated
 
 // Deprecated; remove in 1.0
+public enum EscapingConfig { case escaping }
+
 @attached(peer)
 public macro Init(
   _ accessLevel: AccessLevelConfig,

--- a/Sources/MemberwiseInitClient/main.swift
+++ b/Sources/MemberwiseInitClient/main.swift
@@ -54,15 +54,23 @@ public typealias CompletionHandler = @Sendable () -> Void
 
 @MemberwiseInit(.public)
 public struct TaskRunner: Sendable {
-  @Init(.escaping) public let onCompletion: CompletionHandler
+  @Init(escaping: true) public let onCompletion: CompletionHandler
 }
 
 @MemberwiseInit(.public)
 public struct Job {
-  @Init(.public, .escaping, label: "for")
+  @Init(.public, escaping: true, label: "for")
   let callback: CompletionHandler
 }
 _ = Job(for: { print("Done!") })
+
+//@MemberwiseInit(.public)
+//public struct TaskRunner: Sendable {
+//  @Init(.escaping) public let onCompletion: CompletionHandler
+//  ┬─────────────────────────────
+//  ╰─ ⚠️ @Init(.escaping) is deprecated
+//     ✏️ Replace '@Init(.escaping)' with '@Init(escaping: true)'
+//}
 
 @MemberwiseInit
 struct Point2D {

--- a/Sources/MemberwiseInitMacros/Macros/Support/DeprecationDiagnostics.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/DeprecationDiagnostics.swift
@@ -1,0 +1,67 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacroExpansion
+
+func deprecationDiagnostics(
+  node: AttributeSyntax,
+  declaration decl: some DeclGroupSyntax
+) -> [Diagnostic] {
+  return diagnoseDotEscaping(decl)
+}
+
+private func diagnoseDotEscaping<D: DeclGroupSyntax>(_ decl: D) -> [Diagnostic] {
+  guard let decl = decl.as(StructDeclSyntax.self) else { return [] }
+
+  return decl.memberBlock.members.compactMap { element -> Diagnostic? in
+    guard
+      let configuration = element.decl
+        .as(VariableDeclSyntax.self)?
+        .customConfiguration
+    else { return nil }
+
+    let dotEscapingIndex = configuration.firstIndex(
+      where: {
+        $0.expression
+          .as(MemberAccessExprSyntax.self)?
+          .declName.baseName.text == "escaping"
+      }
+    )
+    guard let dotEscapingIndex else { return nil }
+
+    let newIndex =
+      configuration.firstIndex(where: { $0.label?.text == "label" })
+      .map { configuration.index(before: $0) }
+      ?? configuration.endIndex
+
+    let newEscaping = LabeledExprSyntax(
+      label: .identifier("escaping"),
+      colon: .colonToken(trailingTrivia: .space),
+      expression: BooleanLiteralExprSyntax(booleanLiteral: true),
+      trailingComma: newIndex != configuration.endIndex ? .commaToken(trailingTrivia: .space) : nil
+    )
+
+    var newConfiguration = configuration
+    newConfiguration.remove(at: dotEscapingIndex)
+    newConfiguration.insert(newEscaping, at: newIndex)
+
+    return Diagnostic(
+      node: configuration,
+      message: MacroExpansionWarningMessage(
+        """
+        @Init(.escaping) is deprecated
+        """
+      ),
+      fixIt: FixIt(
+        message: MacroExpansionFixItMessage(
+          "Replace '@Init(.escaping)' with '@Init(escaping: true)'"
+        ),
+        changes: [
+          FixIt.Change.replace(
+            oldNode: Syntax(configuration),
+            newNode: Syntax(newConfiguration)
+          )
+        ]
+      )
+    )
+  }
+}

--- a/Tests/MemberwiseInitTests/MemberwiseInitDeprecationTests.swift
+++ b/Tests/MemberwiseInitTests/MemberwiseInitDeprecationTests.swift
@@ -1,0 +1,184 @@
+import MacroTesting
+import MemberwiseInitMacros
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+final class MemberwiseInitDeprecationTests: XCTestCase {
+  override func invokeTest() {
+    // NB: Waiting for swift-macro-testing PR to support explicit indentationWidth: https://github.com/pointfreeco/swift-macro-testing/pull/8
+    withMacroTesting(
+      //indentationWidth: .spaces(2),
+      macros: [
+        "MemberwiseInit": MemberwiseInitMacro.self,
+        "Init": InitMacro.self,
+      ]
+    ) {
+      super.invokeTest()
+    }
+  }
+
+  // Deprecated; remove in 1.0
+  func testDotEscaping1() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(.escaping) var value: T
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(.escaping) var value: T
+              ┬────────
+              ╰─ ⚠️ @Init(.escaping) is deprecated
+                 ✏️ Replace '@Init(.escaping)' with '@Init(escaping: true)'
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(escaping: true) var value: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        var value: T
+
+        internal init(
+          value: @escaping T
+        ) {
+          self.value = value
+        }
+      }
+      """
+    }
+  }
+
+  // Deprecated; remove in 1.0
+  func testDotEscaping2() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(.public, .escaping) var value: T
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(.public, .escaping) var value: T
+              ┬─────────────────
+              ╰─ ⚠️ @Init(.escaping) is deprecated
+                 ✏️ Replace '@Init(.escaping)' with '@Init(escaping: true)'
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(.public, escaping: true) var value: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        var value: T
+
+        internal init(
+          value: @escaping T
+        ) {
+          self.value = value
+        }
+      }
+      """
+    }
+  }
+
+  // Deprecated; remove in 1.0
+  func testDotEscaping3() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(.escaping, label: "_") var value: T
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(.escaping, label: "_") var value: T
+              ┬────────────────────
+              ╰─ ⚠️ @Init(.escaping) is deprecated
+                 ✏️ Replace '@Init(.escaping)' with '@Init(escaping: true)'
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(escaping: true, label: "_") var value: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        var value: T
+
+        internal init(
+          _ value: @escaping T
+        ) {
+          self.value = value
+        }
+      }
+      """
+    }
+  }
+
+  // Deprecated; remove in 1.0
+  func testDotEscaping4() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(.public, .escaping, label: "_") var value: T
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(.public, .escaping, label: "_") var value: T
+              ┬─────────────────────────────
+              ╰─ ⚠️ @Init(.escaping) is deprecated
+                 ✏️ Replace '@Init(.escaping)' with '@Init(escaping: true)'
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(.public, escaping: true, label: "_") var value: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        var value: T
+
+        internal init(
+          _ value: @escaping T
+        ) {
+          self.value = value
+        }
+      }
+      """
+    }
+  }
+}

--- a/Tests/MemberwiseInitTests/MemberwiseInitTests.swift
+++ b/Tests/MemberwiseInitTests/MemberwiseInitTests.swift
@@ -899,7 +899,7 @@ final class MemberwiseInitTests: XCTestCase {
       """
       @MemberwiseInit(.internal)
       public struct Person {
-        @Init(.public, .escaping) private let name: String
+        @Init(.public, escaping: true) private let name: String
       }
       """
     } expansion: {
@@ -1490,7 +1490,7 @@ final class MemberwiseInitTests: XCTestCase {
 
       @MemberwiseInit(.public)
       public struct Job {
-        @Init(.public, .escaping, label: "for")
+        @Init(.public, escaping: true, label: "for")
         let callback: CompletionHandler
       }
       """
@@ -1588,7 +1588,7 @@ final class MemberwiseInitTests: XCTestCase {
 
       @MemberwiseInit
       struct TaskRunner: Sendable {
-        @Init(.escaping) let log: LoggingMechanism
+        @Init(escaping: true) let log: LoggingMechanism
       }
       """
     } expansion: {
@@ -1614,7 +1614,7 @@ final class MemberwiseInitTests: XCTestCase {
       """
       @MemberwiseInit
       struct Config: Sendable {
-        @Init(.escaping) let version: Int
+        @Init(escaping: true) let version: Int
       }
       """
     } expansion: {


### PR DESCRIPTION
Includes deprecation warning diagnostics with fix-its.