### PR TITLE
Add fluent property wrapper initialization

### DIFF
--- a/Sources/MemberwiseInit/MemberwiseInit.swift
+++ b/Sources/MemberwiseInit/MemberwiseInit.swift
@@ -39,6 +39,29 @@ public enum IgnoreConfig {
 @attached(peer)
 public macro Init(
   _ accessLevel: AccessLevelConfig? = nil,
+  escaping: Bool? = nil,
+  label: String? = nil
+) =
+  #externalMacro(
+    module: "MemberwiseInitMacros",
+    type: "InitMacro"
+  )
+
+@attached(peer)
+public macro InitWrapper(
+  _ accessLevel: AccessLevelConfig? = nil,
+  escaping: Bool? = nil,
+  label: String? = nil,
+  type: Any.Type
+) =
+  #externalMacro(
+    module: "MemberwiseInitMacros",
+    type: "InitMacro"
+  )
+
+@attached(peer)
+public macro InitRaw(
+  _ accessLevel: AccessLevelConfig? = nil,
   assignee: String? = nil,
   escaping: Bool? = nil,
   label: String? = nil,

--- a/Sources/MemberwiseInitClient/main.swift
+++ b/Sources/MemberwiseInitClient/main.swift
@@ -122,6 +122,62 @@ public struct InferType<T: CaseIterable> {
   var dictionaryAs = ["foo": 1, 3: "bar"] as [AnyHashable: Any]
 }
 
+// - MARK: Usage tour
+
+public typealias SimpleClosure = () -> Void
+
+@propertyWrapper
+public struct Logged<Value> {
+  public var wrappedValue: Value {
+    didSet {
+      print("Logged: \(wrappedValue)")
+    }
+  }
+
+  public init(wrappedValue: Value) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
+@MemberwiseInit(.public)
+public struct Usage<T> {
+  @Init(.ignore) var ignored: T? = nil
+  @Init(.public) var initPublic: T
+  @Init(.public, escaping: true) var initPublicEscaping: SimpleClosure
+  @Init(.public, escaping: true, label: "_") var initPublicEscapingLabel: SimpleClosure
+
+  // Some property wrappers require initialization of the property wrapper
+  // itself, hence `@InitWrapper`.
+  @InitWrapper(type: Logged<String>)
+  @Logged
+  public var nameWithWrapper: String
+
+  // `@InitRaw` enables direct specification of initialization values.
+  @InitRaw(
+    .public,
+    assignee: "self._nameWithWrapperRaw",
+    escaping: false,
+    label: "_",
+    type: Logged<String>
+  )
+  @Logged
+  var nameWithWrapperRaw: String
+}
+
+// - MARK: Diagnostics
+
+//@MemberwiseInit
+//struct Diagnostics<T> {
+//  @Init @InitWrapper @InitRaw
+////                   ┬───────
+////      │            ╰─ 🛑 Multiple @Init configurations are not supported by @MemberwiseInit
+////      ┬───────────
+////      ╰─ 🛑 Multiple @Init configurations are not supported by @MemberwiseInit
+//  let value: T
+//}
+
+// - MARK: @Init(label:)
+
 @MemberwiseInit
 struct S1 {
   @Init(label: "b") let _a: String

--- a/Sources/MemberwiseInitMacros/Macros/Support/CustomConfiguration.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/CustomConfiguration.swift
@@ -1,12 +1,24 @@
 import SwiftSyntax
 
 extension VariableDeclSyntax {
-  var customConfiguration: LabeledExprListSyntax? {
+  var customConfigurationAttributes: [AttributeSyntax] {
     self.attributes
-      .first(where: {
-        $0.as(AttributeSyntax.self)?.attributeName.trimmedDescription == "Init"
-      })?
-      .as(AttributeSyntax.self)?
+      .compactMap { $0.as(AttributeSyntax.self) }
+      .filter {
+        ["Init", "InitWrapper", "InitRaw"].contains($0.attributeName.trimmedDescription)
+      }
+  }
+
+  var customConfigurationAttribute: AttributeSyntax? {
+    self.customConfigurationAttributes.first
+  }
+
+  var hasCustomConfigurationAttribute: Bool {
+    !self.customConfigurationAttributes.isEmpty
+  }
+
+  var customConfigurationArguments: LabeledExprListSyntax? {
+    self.customConfigurationAttribute?
       .arguments?
       .as(LabeledExprListSyntax.self)
   }
@@ -15,5 +27,11 @@ extension VariableDeclSyntax {
 extension LabeledExprListSyntax {
   func firstWhereLabel(_ label: String) -> Element? {
     first(where: { $0.label?.text == label })
+  }
+}
+
+extension AttributeSyntax {
+  var isInitWrapper: Bool {
+    self.attributeName.as(IdentifierTypeSyntax.self)?.name.text == "InitWrapper"
   }
 }

--- a/Sources/MemberwiseInitMacros/Macros/Support/DeprecationDiagnostics.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/DeprecationDiagnostics.swift
@@ -16,7 +16,7 @@ private func diagnoseDotEscaping<D: DeclGroupSyntax>(_ decl: D) -> [Diagnostic] 
     guard
       let configuration = element.decl
         .as(VariableDeclSyntax.self)?
-        .customConfiguration
+        .customConfigurationArguments
     else { return nil }
 
     let dotEscapingIndex = configuration.firstIndex(

--- a/Tests/MemberwiseInitTests/CustomInitRawTests.swift
+++ b/Tests/MemberwiseInitTests/CustomInitRawTests.swift
@@ -1,0 +1,134 @@
+import MacroTesting
+import MemberwiseInitMacros
+import SwiftSyntaxMacros
+import XCTest
+
+final class CustomInitRawTests: XCTestCase {
+  override func invokeTest() {
+    // NB: Waiting for swift-macro-testing PR to support explicit indentationWidth: https://github.com/pointfreeco/swift-macro-testing/pull/8
+    withMacroTesting(
+      //indentationWidth: .spaces(2),
+      macros: [
+        "MemberwiseInit": MemberwiseInitMacro.self,
+        "InitRaw": InitMacro.self,
+      ]
+    ) {
+      super.invokeTest()
+    }
+  }
+
+  func testInitRaw() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @InitRaw var type: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        var type: T
+
+        internal init(
+          type: T
+        ) {
+          self.type = type
+        }
+      }
+      """
+    }
+  }
+
+  func testType() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @InitRaw(type: Q) var type: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        var type: T
+
+        internal init(
+          type: Q
+        ) {
+          self.type = type
+        }
+      }
+      """
+    }
+  }
+
+  func testTypeAsGenericExpression() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @InitRaw(type: Q<R>) var type: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        var type: T
+
+        internal init(
+          type: Q<R>
+        ) {
+          self.type = type
+        }
+      }
+      """
+    }
+  }
+
+  func testEverything() {
+    assertMacro {
+      """
+      @MemberwiseInit(.public)
+      public struct S {
+        @InitRaw(.public, assignee: "self.foo", escaping: true, label: "_", type: Q<T>)
+        var initRaw: T
+      }
+      """
+    } expansion: {
+      """
+      public struct S {
+        var initRaw: T
+
+        public init(
+          _ initRaw: @escaping Q<T>
+        ) {
+          self.foo = initRaw
+        }
+      }
+      """
+    }
+  }
+
+  // TODO: Add fix-it diagnostic when provided type is a Metatype
+  //  func testTypeAsMetatype_FailsWithDiagnostic() {
+  //    assertMacro(record: true) {
+  //      """
+  //      @MemberwiseInit
+  //      struct S {
+  //        @Init(type: Q.self) var type: T
+  //      }
+  //      """
+  //    } diagnostics: {
+  //      """
+  //      @MemberwiseInit
+  //      struct S {
+  //        @Init(type: Q.self) var type: T
+  //            ┬─────────────────
+  //            ╰─ 🛑 Invalid use of metatype 'Q.self'. Expected a type, not its metatype.
+  //            ╰─ 🛑 Remove '.self'; type is expected, not a metatype.
+  //      }
+  //      """
+  //    }
+  //  }
+}

--- a/Tests/MemberwiseInitTests/CustomInitWrapperTests.swift
+++ b/Tests/MemberwiseInitTests/CustomInitWrapperTests.swift
@@ -1,0 +1,116 @@
+import MacroTesting
+import MemberwiseInitMacros
+import SwiftSyntaxMacros
+import XCTest
+
+final class CustomInitWrapperTests: XCTestCase {
+  override func invokeTest() {
+    // NB: Waiting for swift-macro-testing PR to support explicit indentationWidth: https://github.com/pointfreeco/swift-macro-testing/pull/8
+    withMacroTesting(
+      //indentationWidth: .spaces(2),
+      macros: [
+        "MemberwiseInit": MemberwiseInitMacro.self,
+        "Init": InitMacro.self,
+        "InitWrapper": InitMacro.self,
+      ]
+    ) {
+      super.invokeTest()
+    }
+  }
+
+  func testType() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @InitWrapper(type: Q<T>)
+        var initWrapper: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        var initWrapper: T
+
+        internal init(
+          initWrapper: Q<T>
+        ) {
+          self._initWrapper = initWrapper
+        }
+      }
+      """
+    }
+  }
+
+  func testEscaping() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @InitWrapper(escaping: true, type: Q<T>)
+        var initWrapper: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        var initWrapper: T
+
+        internal init(
+          initWrapper: @escaping Q<T>
+        ) {
+          self._initWrapper = initWrapper
+        }
+      }
+      """
+    }
+  }
+
+  func testLabel() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @InitWrapper(label: "_", type: Q<T>)
+        var initWrapper: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        var initWrapper: T
+
+        internal init(
+          _ initWrapper: Q<T>
+        ) {
+          self._initWrapper = initWrapper
+        }
+      }
+      """
+    }
+  }
+
+  func testEverything() {
+    assertMacro {
+      """
+      @MemberwiseInit(.public)
+      public struct S {
+        @InitWrapper(.public, escaping: true, label: "_", type: Q<T>)
+        var initWrapper: T
+      }
+      """
+    } expansion: {
+      """
+      public struct S {
+        var initWrapper: T
+
+        public init(
+          _ initWrapper: @escaping Q<T>
+        ) {
+          self._initWrapper = initWrapper
+        }
+      }
+      """
+    }
+  }
+}

--- a/Tests/MemberwiseInitTests/MemberwiseInitTests.swift
+++ b/Tests/MemberwiseInitTests/MemberwiseInitTests.swift
@@ -20,101 +20,6 @@ final class MemberwiseInitTests: XCTestCase {
     }
   }
 
-  // MARK: - Test custom type
-
-  func testCustomType() {
-    assertMacro {
-      """
-      @MemberwiseInit
-      struct S {
-        @Init(type: Q) var type: T
-      }
-      """
-    } expansion: {
-      """
-      struct S {
-        var type: T
-
-        internal init(
-          type: Q
-        ) {
-          self.type = type
-        }
-      }
-      """
-    }
-  }
-
-  func testCustomType_GenericExpression() {
-    assertMacro {
-      """
-      @MemberwiseInit
-      struct S {
-        @Init(type: Q<R>) var type: T
-      }
-      """
-    } expansion: {
-      """
-      struct S {
-        var type: T
-
-        internal init(
-          type: Q<R>
-        ) {
-          self.type = type
-        }
-      }
-      """
-    }
-  }
-
-  // TODO: Add fix-it diagnostic when provided type is a Metatype
-  //  func testCustomType_MetatypeFailsWithDiagnostic() {
-  //    assertMacro(record: true) {
-  //      """
-  //      @MemberwiseInit
-  //      struct S {
-  //        @Init(type: Q.self) var type: T
-  //      }
-  //      """
-  //    } diagnostics: {
-  //      """
-  //      @MemberwiseInit
-  //      struct S {
-  //        @Init(type: Q.self) var type: T
-  //            ┬─────────────────
-  //            ╰─ 🛑 Invalid use of metatype 'Q.self'. Expected a type, not its metatype.
-  //            ╰─ 🛑 Remove '.self'; type is expected, not a metatype.
-  //      }
-  //      """
-  //    }
-  //  }
-
-  // MARK: - Test custom assign
-
-  func testCustomAssign() {
-    assertMacro {
-      """
-      @MemberwiseInit
-      struct S {
-        @Init(assignee: "self._type") var type: T
-      }
-      """
-    } expansion: {
-      """
-      struct S {
-        var type: T
-
-        internal init(
-          type: T
-        ) {
-          self._type = type
-        }
-      }
-      """
-    }
-  }
-
   // MARK: - Test simple usage
 
   // NB: Redundant to AccessLevelTests but handy to have here, too.
@@ -912,6 +817,52 @@ final class MemberwiseInitTests: XCTestCase {
         ) {
           self.name = name
         }
+      }
+      """
+    }
+  }
+
+  func testInitAndInit_FailsWithDiagnostic() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init @Init
+        let value: T
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init @Init
+              ┬────
+              ╰─ 🛑 Multiple @Init configurations are not supported by @MemberwiseInit
+        let value: T
+      }
+      """
+    }
+  }
+
+  func testInitInitWrapperInitRaw_FailsWithDiagnostics() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init @InitWrapper @InitRaw
+        let value: T
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init @InitWrapper @InitRaw
+                           ┬───────
+              │            ╰─ 🛑 Multiple @Init configurations are not supported by @MemberwiseInit
+              ┬───────────
+              ╰─ 🛑 Multiple @Init configurations are not supported by @MemberwiseInit
+        let value: T
       }
       """
     }


### PR DESCRIPTION
* Add `@InitWrapper(type:)` macro.

* Revise `@Init` macro to streamline common usage: Removed 'assignee' and 'type' parameters. This change is non-breaking, as these parameters were added recently and never released (see #13).

* Add `@InitRaw` macro: Provides full configurability over 'accessLevel', 'assignee', 'default', 'escaping', 'label', and 'type'.

* Added diagnostic when multiple `@Init` configurations are applied to a single property.

Resolves #17.