### PR TITLE
Fix incorrect access level diagnostics for computed properties

### DIFF
--- a/Sources/MemberwiseInitMacros/Macros/MemberwiseInitMacro.swift
+++ b/Sources/MemberwiseInitMacros/Macros/MemberwiseInitMacro.swift
@@ -149,7 +149,8 @@ public struct MemberwiseInitMacro: MemberMacro {
         guard
           let variable = member.decl.as(VariableDeclSyntax.self),
           variable.attributes.isEmpty || variable.hasCustomConfigurationAttribute,
-          variable.modifiersExclude([.static, .lazy])
+          variable.modifiersExclude([.static, .lazy]),
+          !variable.isComputedProperty
         else { return }
 
         if variable.customConfigurationAttributes.count > 1 {
@@ -309,7 +310,7 @@ public struct MemberwiseInitMacro: MemberMacro {
         diagnostics: [Diagnostic]()
       )
     ) { acc, propertyBinding in
-      if propertyBinding.isComputedProperty || propertyBinding.isInitializedLet {
+      if propertyBinding.isInitializedLet {
         return
       }
 

--- a/Sources/MemberwiseInitMacros/Macros/Support/SyntaxHelpers.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/SyntaxHelpers.swift
@@ -61,6 +61,15 @@ extension PatternSyntax {
 }
 
 extension VariableDeclSyntax {
+  var isComputedProperty: Bool {
+    guard
+      self.bindings.count == 1,
+      let binding = self.bindings.first?.as(PatternBindingSyntax.self)
+    else { return false }
+
+    return self.bindingSpecifier.tokenKind == .keyword(.var) && binding.isComputedProperty
+  }
+
   var isFullyInitializedLet: Bool {
     self.bindingSpecifier.tokenKind == .keyword(.let)
       && self.bindings.allSatisfy { $0.initializer != nil }

--- a/Tests/MemberwiseInitTests/MemberwiseInitTests.swift
+++ b/Tests/MemberwiseInitTests/MemberwiseInitTests.swift
@@ -541,7 +541,7 @@ final class MemberwiseInitTests: XCTestCase {
       """
       @MemberwiseInit
       struct Person {
-        var hasGoodFavoriteNumber: Bool {
+        private var hasGoodFavoriteNumber: Bool {
           true
         }
       }
@@ -549,7 +549,7 @@ final class MemberwiseInitTests: XCTestCase {
     } expansion: {
       """
       struct Person {
-        var hasGoodFavoriteNumber: Bool {
+        private var hasGoodFavoriteNumber: Bool {
           true
         }
 


### PR DESCRIPTION
Instead of being ignored, computed properties were mistakenly triggering access level diagnostics, suggesting that the visibility of the synthesized initializer was incorrectly exposing less accessible members.

The fix is to exclude computed properties earlier.