### PR TITLE
Limit `@Init(default:)` to single variable bindings

### DIFF
--- a/Sources/MemberwiseInitMacros/Macros/Support/Diagnostics.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/Diagnostics.swift
@@ -2,6 +2,7 @@ import SwiftDiagnostics
 import SwiftSyntax
 
 enum MemberwiseInitMacroDiagnostic: Error, DiagnosticMessage {
+  case defaultAppliedToMultipleBindings
   case labelAppliedToMultipleBindings
   case labelConflictsWithProperty(String)
   case labelConflictsWithAnotherLabel(String)
@@ -12,6 +13,9 @@ enum MemberwiseInitMacroDiagnostic: Error, DiagnosticMessage {
 
   private var rawValue: String {
     switch self {
+    case .defaultAppliedToMultipleBindings:
+      ".defaultAppliedToMultipleBindings"
+
     case .labelAppliedToMultipleBindings:
       ".labelAppliedToMultipleBindings"
 
@@ -39,6 +43,9 @@ enum MemberwiseInitMacroDiagnostic: Error, DiagnosticMessage {
 
   var message: String {
     switch self {
+    case .defaultAppliedToMultipleBindings:
+      return "Custom 'default' can't be applied to multiple bindings"
+
     case .labelAppliedToMultipleBindings:
       return """
         Custom 'label' can't be applied to multiple bindings

--- a/Tests/MemberwiseInitTests/CustomInitDefaultTests.swift
+++ b/Tests/MemberwiseInitTests/CustomInitDefaultTests.swift
@@ -2,6 +2,8 @@ import MacroTesting
 import MemberwiseInitMacros
 import XCTest
 
+// TODO: Carefully consider whether to allow @Init(default:) to be applied to multiple bindings
+
 final class CustomInitDefaultTests: XCTestCase {
   override func invokeTest() {
     // NB: Waiting for swift-macro-testing PR to support explicit indentationWidth: https://github.com/pointfreeco/swift-macro-testing/pull/8
@@ -114,21 +116,30 @@ final class CustomInitDefaultTests: XCTestCase {
         @Init(default: 42) let x, y: Int
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit
       struct S {
         @Init(default: 42) let x, y: Int
-
-        internal init(
-          x: Int = 42,
-          y: Int = 42
-        ) {
-          self.x = x
-          self.y = y
-        }
+              ┬──────────
+              ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
       }
       """
     }
+    //    } expansion: {
+    //      """
+    //      struct S {
+    //        @Init(default: 42) let x, y: Int
+    //
+    //        internal init(
+    //          x: Int = 42,
+    //          y: Int = 42
+    //        ) {
+    //          self.x = x
+    //          self.y = y
+    //        }
+    //      }
+    //      """
   }
 
   func testVarWithMultipleBindings() {
@@ -139,21 +150,30 @@ final class CustomInitDefaultTests: XCTestCase {
         @Init(default: 42) var x, y: Int
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit
       struct S {
         @Init(default: 42) var x, y: Int
-
-        internal init(
-          x: Int = 42,
-          y: Int = 42
-        ) {
-          self.x = x
-          self.y = y
-        }
+              ┬──────────
+              ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
       }
       """
     }
+    //    } expansion: {
+    //      """
+    //      struct S {
+    //        @Init(default: 42) var x, y: Int
+    //
+    //        internal init(
+    //          x: Int = 42,
+    //          y: Int = 42
+    //        ) {
+    //          self.x = x
+    //          self.y = y
+    //        }
+    //      }
+    //      """
   }
 
   func testLetWithFirstBindingInitialized() {
@@ -164,19 +184,28 @@ final class CustomInitDefaultTests: XCTestCase {
         @Init(default: 42) let x = 0, y: Int
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit
       struct S {
         @Init(default: 42) let x = 0, y: Int
-
-        internal init(
-          y: Int = 42
-        ) {
-          self.y = y
-        }
+              ┬──────────
+              ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
       }
       """
     }
+    //    } expansion: {
+    //      """
+    //      struct S {
+    //        @Init(default: 42) let x = 0, y: Int
+    //
+    //        internal init(
+    //          y: Int = 42
+    //        ) {
+    //          self.y = y
+    //        }
+    //      }
+    //      """
   }
 
   func testVarWithFirstBindingInitialized() {
@@ -187,21 +216,30 @@ final class CustomInitDefaultTests: XCTestCase {
         @Init(default: 42) var x = 0, y: Int
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit
       struct S {
         @Init(default: 42) var x = 0, y: Int
-
-        internal init(
-          x: Int = 0,
-          y: Int = 42
-        ) {
-          self.x = x
-          self.y = y
-        }
+              ┬──────────
+              ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
       }
       """
     }
+    //    } expansion: {
+    //      """
+    //      struct S {
+    //        @Init(default: 42) var x = 0, y: Int
+    //
+    //        internal init(
+    //          x: Int = 0,
+    //          y: Int = 42
+    //        ) {
+    //          self.x = x
+    //          self.y = y
+    //        }
+    //      }
+    //      """
   }
 
   func testLetWithRaggedBindings_SucceedsWithInvalidCode() {
@@ -212,20 +250,29 @@ final class CustomInitDefaultTests: XCTestCase {
         @Init(default: 42) let x: Int, isOn: Bool
       }
       """
-    } expansion: {
+    } diagnostics: {
       """
+      @MemberwiseInit
       struct S {
         @Init(default: 42) let x: Int, isOn: Bool
-
-        internal init(
-          x: Int = 42,
-          isOn: Bool = 42
-        ) {
-          self.x = x
-          self.isOn = isOn
-        }
+              ┬──────────
+              ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
       }
       """
     }
+    //    } expansion: {
+    //      """
+    //      struct S {
+    //        @Init(default: 42) let x: Int, isOn: Bool
+    //
+    //        internal init(
+    //          x: Int = 42,
+    //          isOn: Bool = 42
+    //        ) {
+    //          self.x = x
+    //          self.isOn = isOn
+    //        }
+    //      }
+    //      """
   }
 }


### PR DESCRIPTION
Amidst tradeoffs needing careful consideration, I opted to (for now) restrict `@Init(default:)` to single variable bindings. Enabling it for multiple bindings in the future would be non-breaking. (Removing it in the future would be a breaking change.)