### PR TITLE
Add tests covering diagnostics amidst multiple errors

### DIFF
--- a/Sources/MemberwiseInitMacros/Macros/Support/Diagnostics.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/Diagnostics.swift
@@ -1,105 +1,164 @@
 import SwiftDiagnostics
 import SwiftSyntax
+import SwiftSyntaxMacroExpansion
 
-enum MemberwiseInitMacroDiagnostic: Error, DiagnosticMessage {
-  case defaultAppliedToMultipleBindings
-  case labelAppliedToMultipleBindings
-  case labelConflictsWithProperty(String)
-  case labelConflictsWithAnotherLabel(String)
-  case invalidDeclarationKind(DeclGroupSyntax)
-  case invalidSwiftLabel
-  case missingTypeForVarProperty
-  case tupleDestructuringInProperty
+// MARK: - Diagnose VariableDeclSyntax
 
-  private var rawValue: String {
-    switch self {
-    case .defaultAppliedToMultipleBindings:
-      ".defaultAppliedToMultipleBindings"
+func diagnoseMultipleConfigurations(variable: VariableDeclSyntax) -> [Diagnostic]? {
+  guard variable.customConfigurationAttributes.count > 1 else { return nil }
 
-    case .labelAppliedToMultipleBindings:
-      ".labelAppliedToMultipleBindings"
-
-    case .invalidDeclarationKind(let declGroup):
-      ".invalidDeclarationKind(\(declGroup.kind))"
-
-    case .invalidSwiftLabel:
-      ".invalidLabel"
-
-    case .labelConflictsWithProperty(let label):
-      ".labelCollidesWithProperty(\(label))"
-
-    case .labelConflictsWithAnotherLabel(let label):
-      ".labelCollidesWithAnotherLabel(\(label))"
-
-    case .missingTypeForVarProperty:
-      ".missingTypeForVarProperty"
-
-    case .tupleDestructuringInProperty:
-      ".tupleUsedInProperty"
-    }
-  }
-
-  var severity: DiagnosticSeverity { .error }
-
-  var message: String {
-    switch self {
-    case .defaultAppliedToMultipleBindings:
-      return "Custom 'default' can't be applied to multiple bindings"
-
-    case .labelAppliedToMultipleBindings:
-      return """
-        Custom 'label' can't be applied to multiple bindings
-        """
-
-    case let .invalidDeclarationKind(declGroup):
-      return """
-        @MemberwiseInit can only be attached to a struct, class, or actor; \
-        not to \(declGroup.descriptiveDeclKind(withArticle: true)).
-        """
-
-    case .invalidSwiftLabel:
-      return "Invalid label value"
-
-    case let .labelConflictsWithProperty(label):
-      return "Label '\(label)' conflicts with a property name"
-
-    case let .labelConflictsWithAnotherLabel(label):
-      return "Label '\(label)' conflicts with another label"
-
-    case .missingTypeForVarProperty:
-      return
-        "@MemberwiseInit requires a type annotation."
-
-    case .tupleDestructuringInProperty:
-      return """
-        @MemberwiseInit does not support tuple destructuring for property declarations. \
-        Use multiple declarations instead.
-        """
-    }
-  }
-
-  var diagnosticID: MessageID {
-    .init(domain: "MemberwiseInitMacro", id: rawValue)
+  return variable.customConfigurationAttributes.dropFirst().map { attribute in
+    Diagnostic(
+      node: attribute,
+      message: MacroExpansionErrorMessage(
+        "Multiple @Init configurations are not supported by @MemberwiseInit"
+      )
+    )
   }
 }
 
-extension DeclGroupSyntax {
-  func descriptiveDeclKind(withArticle article: Bool = false) -> String {
-    switch self {
-    case is ActorDeclSyntax:
-      return article ? "an actor" : "actor"
-    case is ClassDeclSyntax:
-      return article ? "a class" : "class"
-    case is ExtensionDeclSyntax:
-      return article ? "an extension" : "extension"
-    case is ProtocolDeclSyntax:
-      return article ? "a protocol" : "protocol"
-    case is StructDeclSyntax:
-      return article ? "a struct" : "struct"
-    case is EnumDeclSyntax:
-      return article ? "an enum" : "enum"
-    default:
-      return "`\(self.kind)`"
+func diagnoseVariableDecl(
+  customSettings: VariableCustomSettings?,
+  variable: VariableDeclSyntax,
+  targetAccessLevel: AccessLevelModifier
+) -> [Diagnostic] {
+  let customSettingsDiagnostics =
+    customSettings.map { settings in
+      [
+        diagnoseVariableLabel(customSettings: settings, variable: variable),
+        diagnoseDefaultValueAppliedToMultipleBindings(
+          customSettings: settings,
+          variable: variable
+        ),
+      ].compactMap { $0 }
+    } ?? []
+
+  let accessibilityDiagnostics = [
+    diagnoseAccessibilityLeak(
+      customSettings: customSettings,
+      variable: variable,
+      targetAccessLevel: targetAccessLevel
+    )
+  ].compactMap { $0 }
+
+  return customSettingsDiagnostics + accessibilityDiagnostics
+}
+
+private func diagnoseVariableLabel(
+  customSettings: VariableCustomSettings,
+  variable: VariableDeclSyntax
+) -> Diagnostic? {
+  if let label = customSettings.label,
+    label != "_",
+    variable.bindings.count > 1
+  {
+    return customSettings.diagnosticOnLabel(
+      MacroExpansionErrorMessage("Custom 'label' can't be applied to multiple bindings")
+    )
+  }
+
+  if customSettings.label?.isInvalidSwiftLabel ?? false {
+    return customSettings.diagnosticOnLabelValue(MacroExpansionErrorMessage("Invalid label value"))
+  }
+
+  return nil
+}
+
+private func diagnoseDefaultValueAppliedToMultipleBindings(
+  customSettings: VariableCustomSettings,
+  variable: VariableDeclSyntax
+) -> Diagnostic? {
+  guard
+    customSettings.defaultValue != nil,
+    variable.bindings.count > 1
+  else { return nil }
+
+  return customSettings.diagnosticOnDefault(
+    MacroExpansionErrorMessage("Custom 'default' can't be applied to multiple bindings")
+  )
+}
+
+private func diagnoseAccessibilityLeak(
+  customSettings: VariableCustomSettings?,
+  variable: VariableDeclSyntax,
+  targetAccessLevel: AccessLevelModifier
+) -> Diagnostic? {
+  let effectiveAccessLevel = customSettings?.accessLevel ?? variable.accessLevel
+
+  guard
+    targetAccessLevel > effectiveAccessLevel,
+    !variable.isFullyInitializedLet
+  else { return nil }
+
+  let customAccess = variable.customConfigurationArguments?
+    .first?
+    .expression
+    .as(MemberAccessExprSyntax.self)
+
+  let targetNode =
+    customAccess?._syntaxNode
+    ?? (variable.modifiers.isEmpty ? variable._syntaxNode : variable.modifiers._syntaxNode)
+
+  return Diagnostic(
+    node: targetNode,
+    message: MacroExpansionErrorMessage(
+      """
+      @MemberwiseInit(.\(targetAccessLevel)) would leak access to '\(effectiveAccessLevel)' property
+      """
+    )
+  )
+}
+
+// MARK: - Diagnose [PropertyBinding] and [MemberProperty]
+
+func customInitLabelDiagnosticsFor(bindings: [PropertyBinding]) -> [Diagnostic] {
+  var diagnostics: [Diagnostic] = []
+
+  let customLabeledBindings = bindings.filter {
+    $0.variable.customSettings?.label != nil
+  }
+
+  // Diagnose custom label conflicts with another custom label
+  var seenCustomLabels: Set<String> = []
+  for binding in customLabeledBindings {
+    guard
+      let customSettings = binding.variable.customSettings,
+      let label = customSettings.label,
+      label != "_"
+    else { continue }
+    defer { seenCustomLabels.insert(label) }
+    if seenCustomLabels.contains(label) {
+      diagnostics.append(
+        customSettings.diagnosticOnLabelValue(
+          MacroExpansionErrorMessage("Label '\(label)' conflicts with another label")
+        )
+      )
     }
   }
+
+  return diagnostics
+}
+
+func customInitLabelDiagnosticsFor(properties: [MemberProperty]) -> [Diagnostic] {
+  var diagnostics: [Diagnostic] = []
+
+  let propertiesByName = Dictionary(uniqueKeysWithValues: properties.map { ($0.name, $0) })
+
+  // Diagnose custom label conflicts with a property
+  for property in properties {
+    guard
+      let propertyCustomSettings = property.customSettings,
+      let label = propertyCustomSettings.label,
+      let duplicated = propertiesByName[label],
+      duplicated != property
+    else { continue }
+
+    diagnostics.append(
+      propertyCustomSettings.diagnosticOnLabelValue(
+        MacroExpansionErrorMessage("Label '\(label)' conflicts with a property name")
+      )
+    )
+  }
+
+  return diagnostics
 }

--- a/Sources/MemberwiseInitMacros/Macros/Support/Models.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/Models.swift
@@ -1,0 +1,148 @@
+import SwiftDiagnostics
+import SwiftSyntax
+
+struct VariableCustomSettings: Equatable {
+  enum Assignee: Equatable {
+    case wrapper
+    case raw(String)
+  }
+
+  let accessLevel: AccessLevelModifier?
+  let assignee: Assignee?
+  let defaultValue: String?
+  let forceEscaping: Bool
+  let ignore: Bool
+  let label: String?
+  let type: TypeSyntax?
+  let _syntaxNode: AttributeSyntax
+
+  func diagnosticOnDefault(_ message: DiagnosticMessage) -> Diagnostic {
+    let labelNode = self._syntaxNode
+      .arguments?
+      .as(LabeledExprListSyntax.self)?
+      .firstWhereLabel("default")
+
+    return diagnostic(node: labelNode ?? self._syntaxNode, message: message)
+  }
+
+  func diagnosticOnLabel(_ message: DiagnosticMessage) -> Diagnostic {
+    let labelNode = self._syntaxNode
+      .arguments?
+      .as(LabeledExprListSyntax.self)?
+      .firstWhereLabel("label")
+
+    return diagnostic(node: labelNode ?? self._syntaxNode, message: message)
+  }
+
+  func diagnosticOnLabelValue(_ message: DiagnosticMessage) -> Diagnostic {
+    let labelValueNode = self._syntaxNode
+      .arguments?
+      .as(LabeledExprListSyntax.self)?
+      .firstWhereLabel("label")?
+      .expression
+
+    return diagnostic(node: labelValueNode ?? self._syntaxNode, message: message)
+  }
+
+  private func diagnostic(
+    node: any SyntaxProtocol,
+    message: DiagnosticMessage
+  ) -> Diagnostic {
+    Diagnostic(node: node, message: message)
+  }
+}
+
+struct PropertyBinding {
+  let typeFromTrailingBinding: TypeSyntax?
+  let syntax: PatternBindingSyntax
+  let variable: MemberVariable
+
+  var effectiveType: TypeSyntax? {
+    variable.customSettings?.type
+      ?? self.syntax.typeAnnotation?.type
+      ?? self.syntax.initializer?.value.inferredTypeSyntax
+      ?? self.typeFromTrailingBinding
+  }
+
+  var initializerValue: ExprSyntax? {
+    self.syntax.initializer?.trimmed.value
+  }
+
+  var isTuplePattern: Bool {
+    self.syntax.pattern.isTuplePattern
+  }
+
+  var name: String? {
+    self.syntax.pattern.as(IdentifierPatternSyntax.self)?.identifier.text
+  }
+
+  var isInitializedVarWithoutType: Bool {
+    self.initializerValue != nil
+      && self.variable.keywordToken == .keyword(.var)
+      && self.effectiveType == nil
+      && self.initializerValue?.inferredTypeSyntax == nil
+  }
+
+  var isInitializedLet: Bool {
+    self.initializerValue != nil && self.variable.keywordToken == .keyword(.let)
+  }
+
+  func diagnostic(_ message: DiagnosticMessage) -> Diagnostic {
+    Diagnostic(node: self.syntax._syntaxNode, message: message)
+  }
+}
+
+struct MemberVariable {
+  let customSettings: VariableCustomSettings?
+  let syntax: VariableDeclSyntax
+
+  var accessLevel: AccessLevelModifier {
+    self.syntax.accessLevel
+  }
+
+  var bindings: PatternBindingListSyntax {
+    self.syntax.bindings
+  }
+
+  var keywordToken: TokenKind {
+    self.syntax.bindingSpecifier.tokenKind
+  }
+}
+
+struct MemberProperty: Equatable {
+  let accessLevel: AccessLevelModifier
+  let customSettings: VariableCustomSettings?
+  let initializerValue: ExprSyntax?
+  let keywordToken: TokenKind
+  let name: String
+  let type: TypeSyntax
+
+  func initParameterLabel(
+    considering allProperties: [MemberProperty],
+    deunderscoreParameters: Bool
+  ) -> String {
+    guard
+      let customSettings = self.customSettings,
+      customSettings.label
+        != self.initParameterName(
+          considering: allProperties,
+          deunderscoreParameters: deunderscoreParameters
+        )
+    else { return "" }
+
+    return customSettings.label.map { "\($0) " } ?? ""
+  }
+
+  func initParameterName(
+    considering allProperties: [MemberProperty],
+    deunderscoreParameters: Bool
+  ) -> String {
+    guard
+      self.customSettings?.label == nil,
+      deunderscoreParameters
+    else { return self.name }
+
+    let potentialName = self.name.hasPrefix("_") ? String(name.dropFirst()) : self.name
+    return allProperties.contains(where: { $0.name == potentialName }) ? self.name : potentialName
+  }
+}

--- a/Sources/MemberwiseInitMacros/Macros/Support/SyntaxHelpers.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/SyntaxHelpers.swift
@@ -84,3 +84,24 @@ extension ExprSyntax {
       .trimmingCharacters(in: .whitespacesAndNewlines)
   }
 }
+
+extension DeclGroupSyntax {
+  func descriptiveDeclKind(withArticle article: Bool = false) -> String {
+    switch self {
+    case is ActorDeclSyntax:
+      return article ? "an actor" : "actor"
+    case is ClassDeclSyntax:
+      return article ? "a class" : "class"
+    case is ExtensionDeclSyntax:
+      return article ? "an extension" : "extension"
+    case is ProtocolDeclSyntax:
+      return article ? "a protocol" : "protocol"
+    case is StructDeclSyntax:
+      return article ? "a struct" : "struct"
+    case is EnumDeclSyntax:
+      return article ? "an enum" : "enum"
+    default:
+      return "`\(self.kind)`"
+    }
+  }
+}

--- a/Tests/MemberwiseInitTests/LayeredDiagnosticsTests.swift
+++ b/Tests/MemberwiseInitTests/LayeredDiagnosticsTests.swift
@@ -1,0 +1,132 @@
+import MacroTesting
+import MemberwiseInitMacros
+import XCTest
+
+final class LayeredDiagnosticsTests: XCTestCase {
+  override func invokeTest() {
+    // NB: Waiting for swift-macro-testing PR to support explicit indentationWidth: https://github.com/pointfreeco/swift-macro-testing/pull/8
+    withMacroTesting(
+      //indentationWidth: .spaces(2),
+      macros: [
+        "MemberwiseInit": MemberwiseInitMacro.self,
+        "InitRaw": InitMacro.self,
+      ]
+    ) {
+      super.invokeTest()
+    }
+  }
+
+  func testInvalidLabelOnMultipleBindings() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(label: "$foo") let x, y: T
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(label: "$foo") let x, y: T
+              ┬────────────
+              ╰─ 🛑 Custom 'label' can't be applied to multiple bindings
+      }
+      """
+    }
+  }
+
+  func testInvalidLabelAndDefaultOnMultipleBindings() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(default: 0, label: "$foo") let x, y: T
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(default: 0, label: "$foo") let x, y: T
+                          ┬────────────
+              │           ╰─ 🛑 Custom 'label' can't be applied to multiple bindings
+              ┬──────────
+              ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
+      }
+      """
+    }
+  }
+
+  func testAccessLeakCustomDefaultAndInvalidLabelOnMultipleBindings() {
+    assertMacro {
+      """
+      @MemberwiseInit(.public)
+      struct S {
+        @Init(default: 0, label: "$foo") private let x, y: T
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit(.public)
+      struct S {
+        @Init(default: 0, label: "$foo") private let x, y: T
+                                         ┬──────
+              │           │              ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
+                          ┬────────────
+              │           ╰─ 🛑 Custom 'label' can't be applied to multiple bindings
+              ┬──────────
+              ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
+      }
+      """
+    }
+  }
+
+  func testAccessLeakAndCustomLabelConflictsWithAnotherLabel() {
+    assertMacro {
+      """
+      @MemberwiseInit(.public)
+      struct S {
+        @Init(label: "foo") let x: T
+        @Init(label: "foo") let y: T
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit(.public)
+      struct S {
+        @Init(label: "foo") let x: T
+        ┬───────────────────────────
+        ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+        @Init(label: "foo") let y: T
+        ┬───────────────────────────
+        ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+      }
+      """
+    }
+  }
+
+  func testAccessLeakAndCustomLabelConflictsWithPropertyName() {
+    assertMacro {
+      """
+      @MemberwiseInit(.public)
+      struct S {
+        @Init(label: "y") let x: T
+        let y: T
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit(.public)
+      struct S {
+        @Init(label: "y") let x: T
+        ┬─────────────────────────
+        ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+        let y: T
+        ┬───────
+        ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+      }
+      """
+    }
+  }
+}


### PR DESCRIPTION
* Refactor diagnostics to avoid maintaining a custom error type
* Mostly centralize diagnostics into Diagnostics.swift
* New tests to verify diagnostics in complex cases with "layered" errors