### PR TITLE
Fix crash on invalid redeclarations

### DIFF
--- a/Sources/MemberwiseInitMacros/Macros/Support/Diagnostics.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/Diagnostics.swift
@@ -142,15 +142,15 @@ func customInitLabelDiagnosticsFor(bindings: [PropertyBinding]) -> [Diagnostic] 
 func customInitLabelDiagnosticsFor(properties: [MemberProperty]) -> [Diagnostic] {
   var diagnostics: [Diagnostic] = []
 
-  let propertiesByName = Dictionary(uniqueKeysWithValues: properties.map { ($0.name, $0) })
+  let propertiesByName = Dictionary(grouping: properties, by: { $0.name })
 
   // Diagnose custom label conflicts with a property
   for property in properties {
     guard
       let propertyCustomSettings = property.customSettings,
       let label = propertyCustomSettings.label,
-      let duplicated = propertiesByName[label],
-      duplicated != property
+      let duplicates = propertiesByName[label],
+      duplicates.contains(where: { $0 != property })
     else { continue }
 
     diagnostics.append(

--- a/Tests/MemberwiseInitTests/InvalidSyntaxTests.swift
+++ b/Tests/MemberwiseInitTests/InvalidSyntaxTests.swift
@@ -1,0 +1,92 @@
+import MacroTesting
+import MemberwiseInitMacros
+import XCTest
+
+final class InvalidSyntaxTests: XCTestCase {
+  override func invokeTest() {
+    // NB: Waiting for swift-macro-testing PR to support explicit indentationWidth: https://github.com/pointfreeco/swift-macro-testing/pull/8
+    withMacroTesting(
+      //indentationWidth: .spaces(2),
+      macros: [
+        "MemberwiseInit": MemberwiseInitMacro.self,
+        "InitRaw": InitMacro.self,
+      ]
+    ) {
+      super.invokeTest()
+    }
+  }
+
+  func testInvalidRedeclaration_SucceedsWithInvalidCode() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        let x: T
+        let x: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        let x: T
+        let x: T
+
+        internal init(
+          x: T,
+          x: T
+        ) {
+          self.x = x
+          self.x = x
+        }
+      }
+      """
+    }
+  }
+
+  func testInvalidRedeclaration2_SucceedsWithInvalidCode() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        let x, x: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        let x, x: T
+
+        internal init(
+          x: T,
+          x: T
+        ) {
+          self.x = x
+          self.x = x
+        }
+      }
+      """
+    }
+  }
+
+  func testInvalidRedeclarationAndCustomLabelConflictsWithPropertyName_FailsWithDiagnostic() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(label: "x") let x: T
+        let x: T
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(label: "x") let x: T
+                     ┬──
+                     ╰─ 🛑 Label 'x' conflicts with a property name
+        let x: T
+      }
+      """
+    }
+  }
+}


### PR DESCRIPTION
Fixes #27.

Crash was when encountering invalid Swift code with redeclarations of properties, e.g., `let x: Int; let x: Int` or `let x, x: Int`.