### PR TITLE
Disallow `@Init(default:)` on already initialized variables

### DIFF
--- a/Sources/MemberwiseInitMacros/Macros/MemberwiseInitMacro.swift
+++ b/Sources/MemberwiseInitMacros/Macros/MemberwiseInitMacro.swift
@@ -154,7 +154,6 @@ public struct MemberwiseInitMacro: MemberMacro {
         guard
           let variable = member.decl.as(VariableDeclSyntax.self),
           variable.attributes.isEmpty || variable.hasCustomConfigurationAttribute,
-          variable.modifiersExclude([.static, .lazy]),
           !variable.isComputedProperty
         else { return }
 
@@ -177,6 +176,8 @@ public struct MemberwiseInitMacro: MemberMacro {
           acc.diagnostics += diagnostics
           return
         }
+
+        guard variable.modifiersExclude([.static, .lazy]) else { return }
 
         acc.variables.append(
           MemberVariable(

--- a/Sources/MemberwiseInitMacros/Macros/Support/AttributeRemover.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/AttributeRemover.swift
@@ -1,0 +1,124 @@
+import SwiftSyntax
+
+/// Removes attributes from a syntax tree while maintaining their surrounding trivia.
+public class AttributeRemover: SyntaxRewriter {
+  let predicate: (AttributeSyntax) -> Bool
+
+  var triviaToAttachToNextToken: Trivia = Trivia()
+
+  /// Initializes an attribute remover with a given predicate to determine which attributes to remove.
+  ///
+  /// - Parameter predicate: A closure that determines whether a given `AttributeSyntax` should be removed.
+  ///   If this closure returns `true` for an attribute, that attribute will be removed.
+  public init(removingWhere predicate: @escaping (AttributeSyntax) -> Bool) {
+    self.predicate = predicate
+  }
+
+  public override func visit(_ nodeList: AttributeListSyntax) -> AttributeListSyntax {
+    var filteredAttributes: [AttributeListSyntax.Element] = []
+
+    for node in nodeList {
+      switch node {
+      case .attribute(let attribute):
+        guard self.predicate(attribute) else {
+          filteredAttributes.append(.attribute(prependAndClearAccumulatedTrivia(to: attribute)))
+          continue
+        }
+
+        var leadingTrivia = attribute.leadingTrivia
+
+        // Don't leave behind an empty line when the attribute being removed is on its own line,
+        // based on the following conditions:
+        //  - Leading trivia ends with a newline followed by arbitrary number of spaces or tabs
+        //  - All leading trivia pieces after the last newline are just whitespace, ensuring
+        //    there are no comments or other non-whitespace characters on the same line
+        //    preceding the attribute.
+        //  - There is no trailing trivia and the next token has leading trivia.
+        if let lastNewline = leadingTrivia.pieces.lastIndex(where: \.isNewline),
+          leadingTrivia.pieces[lastNewline...].allSatisfy(\.isWhitespace),
+          attribute.trailingTrivia.isEmpty,
+          let nextToken = attribute.nextToken(viewMode: .sourceAccurate),
+          !nextToken.leadingTrivia.isEmpty
+        {
+          leadingTrivia = Trivia(pieces: leadingTrivia.pieces[..<lastNewline])
+        }
+
+        // Drop any spaces or tabs from the trailing trivia because there’s no
+        // more attribute they need to separate.
+        let trailingTrivia = attribute.trailingTrivia.trimmingPrefix(while: \.isSpaceOrTab)
+        self.triviaToAttachToNextToken += leadingTrivia + trailingTrivia
+
+        // If the attribute is not separated from the previous attribute by trivia, as in
+        // `@First@Second var x: Int` (yes, that's valid Swift), removing the `@Second`
+        // attribute and dropping all its trivia would cause `@First` and `var` to join
+        // without any trivia in between, which is invalid. In such cases, the trailing trivia
+        // of the attribute is significant and must be retained.
+        if self.triviaToAttachToNextToken.isEmpty,
+          let previousToken = attribute.previousToken(viewMode: .sourceAccurate),
+          previousToken.trailingTrivia.isEmpty
+        {
+          self.triviaToAttachToNextToken = attribute.trailingTrivia
+        }
+
+      case .ifConfigDecl(_):
+        filteredAttributes.append(node)
+      }
+    }
+
+    // Ensure that any horizontal whitespace trailing the attributes list is trimmed if the next
+    // token starts a new line.
+    if let nextToken = nodeList.nextToken(viewMode: .sourceAccurate),
+      nextToken.leadingTrivia.startsWithNewline
+    {
+      if !self.triviaToAttachToNextToken.isEmpty {
+        self.triviaToAttachToNextToken = self.triviaToAttachToNextToken.trimmingSuffix(
+          while: \.isSpaceOrTab)
+      } else if let lastAttribute = filteredAttributes.last {
+        filteredAttributes[filteredAttributes.count - 1].trailingTrivia = lastAttribute
+          .trailingTrivia.trimmingSuffix(while: \.isSpaceOrTab)
+      }
+    }
+    return AttributeListSyntax(filteredAttributes)
+  }
+
+  public override func visit(_ token: TokenSyntax) -> TokenSyntax {
+    return prependAndClearAccumulatedTrivia(to: token)
+  }
+
+  /// Prepends the accumulated trivia to the given node's leading trivia.
+  ///
+  /// To preserve correct formatting after attribute removal, this function reassigns
+  /// significant trivia accumulated from removed attributes to the provided subsequent node.
+  /// Once attached, the accumulated trivia is cleared.
+  ///
+  /// - Parameter node: The syntax node receiving the accumulated trivia.
+  /// - Returns: The modified syntax node with the prepended trivia.
+  private func prependAndClearAccumulatedTrivia<T: SyntaxProtocol>(to syntaxNode: T) -> T {
+    defer { self.triviaToAttachToNextToken = Trivia() }
+    return syntaxNode.with(
+      \.leadingTrivia, self.triviaToAttachToNextToken + syntaxNode.leadingTrivia)
+  }
+}
+
+extension Trivia {
+  fileprivate func trimmingPrefix(
+    while predicate: (TriviaPiece) -> Bool
+  ) -> Trivia {
+    Trivia(pieces: self.drop(while: predicate))
+  }
+
+  fileprivate func trimmingSuffix(
+    while predicate: (TriviaPiece) -> Bool
+  ) -> Trivia {
+    Trivia(
+      pieces: self[...]
+        .reversed()
+        .drop(while: predicate)
+        .reversed()
+    )
+  }
+
+  fileprivate var startsWithNewline: Bool {
+    self.first?.isNewline ?? false
+  }
+}

--- a/Sources/MemberwiseInitMacros/Macros/Support/CustomConfiguration.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/CustomConfiguration.swift
@@ -13,6 +13,17 @@ extension VariableDeclSyntax {
     self.customConfigurationAttributes.first
   }
 
+  var hasNonConfigurationAttributes: Bool {
+    self.attributes.filter { attribute in
+      switch attribute {
+      case .attribute:
+        true
+      case .ifConfigDecl:
+        false
+      }
+    }.count != self.customConfigurationAttributes.count
+  }
+
   var hasCustomConfigurationAttribute: Bool {
     !self.customConfigurationAttributes.isEmpty
   }
@@ -21,6 +32,16 @@ extension VariableDeclSyntax {
     self.customConfigurationAttribute?
       .arguments?
       .as(LabeledExprListSyntax.self)
+  }
+
+  func hasSoleArgument(_ label: String) -> Bool {
+    guard let arguments = self.customConfigurationArguments else { return false }
+    return arguments.count == 1 && arguments.first?.label?.text == label
+  }
+
+  func includesArgument(_ label: String) -> Bool {
+    guard let arguments = self.customConfigurationArguments else { return false }
+    return arguments.first(where: { $0.label?.text == label }) != nil
   }
 }
 

--- a/Sources/MemberwiseInitMacros/Macros/Support/Diagnostics.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/Diagnostics.swift
@@ -24,14 +24,24 @@ func diagnoseVariableDecl(
 ) -> [Diagnostic] {
   let customSettingsDiagnostics =
     customSettings.map { settings in
-      [
+      if let diagnostic = diagnoseInitOnInitializedLet(customSettings: settings, variable: variable)
+      {
+        return [diagnostic]
+      }
+
+      if let diagnostic = diagnoseMemberModifiers(customSettings: settings, variable: variable) {
+        return [diagnostic]
+      }
+
+      return [
         diagnoseVariableLabel(customSettings: settings, variable: variable),
         diagnoseDefaultValueAppliedToMultipleBindings(
           customSettings: settings,
           variable: variable
-        ),
+        )
+          ?? diagnoseDefaultValueAppliedToInitialized(customSettings: settings, variable: variable),
       ].compactMap { $0 }
-    } ?? []
+    } ?? [Diagnostic]()
 
   let accessibilityDiagnostics = [
     diagnoseAccessibilityLeak(
@@ -42,6 +52,68 @@ func diagnoseVariableDecl(
   ].compactMap { $0 }
 
   return customSettingsDiagnostics + accessibilityDiagnostics
+}
+
+private func diagnoseInitOnInitializedLet(
+  customSettings: VariableCustomSettings,
+  variable: VariableDeclSyntax
+) -> Diagnostic? {
+  guard
+    variable.isLet,
+    variable.isFullyInitialized
+  else { return nil }
+
+  let fixIts = [
+    variable.fixItRemoveCustomInit,
+    variable.fixItRemoveInitializer,
+  ].compactMap { $0 }
+
+  var diagnosticMessage: DiagnosticMessage {
+    let attributeName = customSettings.customAttributeName
+
+    let message = "@\(attributeName) can't be applied to already initialized constant"
+
+    // @InitWrapper and @InitRaw can be errors instead of warnings since they haven't seen release.
+    if attributeName != "Init" {
+      return MacroExpansionErrorMessage(message)
+    }
+    // @Init(default:) hasn't seen release, so any misuses that include "default" can be an error.
+    if variable.includesArgument("default") {
+      return MacroExpansionErrorMessage(message)
+    }
+
+    // TODO: For 1.0, @Init can also be an error
+    // Conservatively, make @Init be a warning to tolerate uses relying on @Init being silently ignored.
+    return MacroExpansionWarningMessage(message)
+  }
+
+  return customSettings.diagnosticOnDefault(diagnosticMessage, fixIts: fixIts)
+}
+
+private func diagnoseMemberModifiers(
+  customSettings: VariableCustomSettings,
+  variable: VariableDeclSyntax
+) -> Diagnostic? {
+  let attributeName = customSettings.customAttributeName
+
+  if let modifier = variable.firstModifierWhere(keyword: .static) {
+    return Diagnostic(
+      node: modifier,
+      message: MacroExpansionWarningMessage(
+        "@\(attributeName) can't be applied to 'static' members"),
+      fixIts: [variable.fixItRemoveCustomInit].compactMap { $0 }
+    )
+  }
+
+  if let modifier = variable.firstModifierWhere(keyword: .lazy) {
+    return Diagnostic(
+      node: modifier,
+      message: MacroExpansionWarningMessage("@\(attributeName) can't be applied to 'lazy' members"),
+      fixIts: [variable.fixItRemoveCustomInit].compactMap { $0 }
+    )
+  }
+
+  return nil
 }
 
 private func diagnoseVariableLabel(
@@ -69,13 +141,61 @@ private func diagnoseDefaultValueAppliedToMultipleBindings(
   variable: VariableDeclSyntax
 ) -> Diagnostic? {
   guard
-    customSettings.defaultValue != nil,
+    let defaultValue = customSettings.defaultValue,
     variable.bindings.count > 1
   else { return nil }
 
+  let fixIts = [
+    determineRemoveDefaultFixIt(variable: variable, defaultValue: defaultValue),
+    determineRemoveCustomInitFixIt(variable: variable),
+  ].compactMap { $0 }
+
   return customSettings.diagnosticOnDefault(
-    MacroExpansionErrorMessage("Custom 'default' can't be applied to multiple bindings")
+    MacroExpansionErrorMessage("Custom 'default' can't be applied to multiple bindings"),
+    fixIts: fixIts
   )
+}
+
+private func diagnoseDefaultValueAppliedToInitialized(
+  customSettings: VariableCustomSettings,
+  variable: VariableDeclSyntax
+) -> Diagnostic? {
+  guard
+    let defaultValue = customSettings.defaultValue,
+    variable.isFullyInitialized
+  else { return nil }
+
+  let fixIts = [
+    determineRemoveDefaultFixIt(variable: variable, defaultValue: defaultValue),
+    determineRemoveCustomInitFixIt(variable: variable),
+    variable.fixItRemoveInitializer,
+  ].compactMap { $0 }
+
+  return customSettings.diagnosticOnDefault(
+    MacroExpansionErrorMessage("Custom 'default' can't be applied to already initialized variable"),
+    fixIts: fixIts
+  )
+}
+
+private func determineRemoveDefaultFixIt(
+  variable: VariableDeclSyntax,
+  defaultValue: String
+) -> FixIt? {
+  let shouldRemoveDefault =
+    variable.isVar
+    && (!variable.hasSoleArgument("default") || variable.hasNonConfigurationAttributes)
+    || variable.bindings.count > 1 && !variable.hasSoleArgument("default")
+
+  return shouldRemoveDefault ? variable.fixItRemoveDefault(defaultValue: defaultValue) : nil
+}
+
+private func determineRemoveCustomInitFixIt(
+  variable: VariableDeclSyntax
+) -> FixIt? {
+  let shouldRemoveCustomInit =
+    !variable.hasNonConfigurationAttributes && variable.hasSoleArgument("default")
+
+  return shouldRemoveCustomInit ? variable.fixItRemoveCustomInit : nil
 }
 
 private func diagnoseAccessibilityLeak(
@@ -161,4 +281,87 @@ func customInitLabelDiagnosticsFor(properties: [MemberProperty]) -> [Diagnostic]
   }
 
   return diagnostics
+}
+
+// MARK: Fix-its
+
+extension VariableDeclSyntax {
+  func fixItRemoveDefault(defaultValue: String) -> FixIt? {
+    guard
+      let customAttribute = self.customConfigurationAttribute,
+      let arguments = self.customConfigurationArguments
+    else { return nil }
+
+    var newAttribute = customAttribute
+    let newArguments = arguments.filter { $0.label?.text != "default" }
+    newAttribute.arguments = newArguments.as(AttributeSyntax.Arguments.self)
+    if newArguments.count == 0 {
+      newAttribute.leftParen = nil
+      newAttribute.rightParen = nil
+    }
+
+    return FixIt(
+      message: MacroExpansionFixItMessage("Remove 'default: \(defaultValue)'"),
+      changes: [
+        FixIt.Change.replace(
+          oldNode: Syntax(customAttribute),
+          newNode: Syntax(newAttribute))
+      ]
+    )
+  }
+
+  var fixItRemoveCustomInit: FixIt? {
+    guard let customAttribute = self.customConfigurationAttribute else { return nil }
+
+    let newVariable = AttributeRemover(
+      removingWhere: {
+        ["Init", "InitWrapper", "InitRaw"].contains($0.attributeName.trimmedDescription)
+      }
+    ).rewrite(self)
+
+    return FixIt(
+      message: MacroExpansionFixItMessage("Remove '\(customAttribute.trimmedDescription)'"),
+      changes: [
+        FixIt.Change.replace(
+          oldNode: Syntax(self), newNode: Syntax(newVariable)
+        )
+      ]
+    )
+  }
+
+  var fixItRemoveInitializer: FixIt? {
+    guard
+      self.bindings.count == 1,
+      let firstBinding = self.bindings.first,
+      let firstBindingInitializer = firstBinding.initializer
+    else { return nil }
+
+    var newFirstBinding = firstBinding.with(\.initializer, nil)
+
+    if firstBinding.typeAnnotation == nil {
+      let inferredTypeSyntax = firstBindingInitializer.value.inferredTypeSyntax
+
+      newFirstBinding.typeAnnotation = TypeAnnotationSyntax(
+        colon: .colonToken(trailingTrivia: .space),
+        type: inferredTypeSyntax
+          ?? MissingTypeSyntax(placeholder: TokenSyntax(stringLiteral: "\u{3C}#Type#\u{3E}"))
+          .as(TypeSyntax.self)!
+      )
+      newFirstBinding.pattern = newFirstBinding.pattern.trimmed
+    }
+
+    var newNode = self.detached
+    newNode.bindings = .init(arrayLiteral: newFirstBinding)
+
+    return FixIt(
+      message: MacroExpansionFixItMessage(
+        "Remove '\(firstBindingInitializer.trimmedDescription)'"
+      ),
+      changes: [
+        FixIt.Change.replace(
+          oldNode: Syntax(self), newNode: Syntax(newNode)
+        )
+      ]
+    )
+  }
 }

--- a/Sources/MemberwiseInitMacros/Macros/Support/Models.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/Models.swift
@@ -16,22 +16,26 @@ struct VariableCustomSettings: Equatable {
   let type: TypeSyntax?
   let _syntaxNode: AttributeSyntax
 
-  func diagnosticOnDefault(_ message: DiagnosticMessage) -> Diagnostic {
+  var customAttributeName: String {
+    self._syntaxNode.attributeName.trimmedDescription
+  }
+
+  func diagnosticOnDefault(_ message: DiagnosticMessage, fixIts: [FixIt] = []) -> Diagnostic {
     let labelNode = self._syntaxNode
       .arguments?
       .as(LabeledExprListSyntax.self)?
       .firstWhereLabel("default")
 
-    return diagnostic(node: labelNode ?? self._syntaxNode, message: message)
+    return diagnostic(node: labelNode ?? self._syntaxNode, message: message, fixIts: fixIts)
   }
 
-  func diagnosticOnLabel(_ message: DiagnosticMessage) -> Diagnostic {
+  func diagnosticOnLabel(_ message: DiagnosticMessage, fixIts: [FixIt] = []) -> Diagnostic {
     let labelNode = self._syntaxNode
       .arguments?
       .as(LabeledExprListSyntax.self)?
       .firstWhereLabel("label")
 
-    return diagnostic(node: labelNode ?? self._syntaxNode, message: message)
+    return diagnostic(node: labelNode ?? self._syntaxNode, message: message, fixIts: fixIts)
   }
 
   func diagnosticOnLabelValue(_ message: DiagnosticMessage) -> Diagnostic {
@@ -46,9 +50,10 @@ struct VariableCustomSettings: Equatable {
 
   private func diagnostic(
     node: any SyntaxProtocol,
-    message: DiagnosticMessage
+    message: DiagnosticMessage,
+    fixIts: [FixIt] = []
   ) -> Diagnostic {
-    Diagnostic(node: node, message: message)
+    Diagnostic(node: node, message: message, fixIts: fixIts)
   }
 }
 

--- a/Sources/MemberwiseInitMacros/Macros/Support/SyntaxHelpers.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/SyntaxHelpers.swift
@@ -1,16 +1,15 @@
 import SwiftSyntax
 
-extension AttributeListSyntax {
-  func contains(attributeNamed name: String) -> Bool {
-    return self.contains {
-      $0.as(AttributeSyntax.self)?.attributeName.trimmedDescription == name
-    }
-  }
-}
-
 extension VariableDeclSyntax {
   func modifiersExclude(_ keywords: [Keyword]) -> Bool {
     return !self.modifiers.containsAny(of: keywords.map { TokenSyntax.keyword($0) })
+  }
+
+  func firstModifierWhere(keyword: Keyword) -> DeclModifierSyntax? {
+    let keywordText = TokenSyntax.keyword(keyword).text
+    return self.modifiers.first { modifier in
+      modifier.name.text == keywordText
+    }
   }
 }
 
@@ -70,9 +69,20 @@ extension VariableDeclSyntax {
     return self.bindingSpecifier.tokenKind == .keyword(.var) && binding.isComputedProperty
   }
 
+  var isFullyInitialized: Bool {
+    self.bindings.allSatisfy { $0.initializer != nil }
+  }
+
   var isFullyInitializedLet: Bool {
+    self.isLet && self.isFullyInitialized
+  }
+
+  var isLet: Bool {
     self.bindingSpecifier.tokenKind == .keyword(.let)
-      && self.bindings.allSatisfy { $0.initializer != nil }
+  }
+
+  var isVar: Bool {
+    self.bindingSpecifier.tokenKind == .keyword(.var)
   }
 }
 

--- a/Tests/MemberwiseInitTests/CustomInitDefaultTests.swift
+++ b/Tests/MemberwiseInitTests/CustomInitDefaultTests.swift
@@ -64,7 +64,8 @@ final class CustomInitDefaultTests: XCTestCase {
     }
   }
 
-  // TODO: For 1.0, diagnostic on nonsensical @Init(default:)?
+  // FIXME: Exclusively applicable fix-its aren't testable: https://github.com/pointfreeco/swift-macro-testing/issues/14
+  // TODO: For 1.0, strengthen by rejecting @Init on already initialized let (not just on '@Init(default:)')
   func testInitializedLet() {
     assertMacro {
       """
@@ -73,10 +74,28 @@ final class CustomInitDefaultTests: XCTestCase {
         @Init(default: 42) let number = 0
       }
       """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(default: 42) let number = 0
+              ┬──────────
+              ╰─ 🛑 @Init can't be applied to already initialized constant
+                 ✏️ Remove '@Init(default: 42)'
+                 ✏️ Remove '= 0'
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct S {
+        let number = 0
+      }
+      """
     } expansion: {
       """
       struct S {
-        @Init(default: 42) let number = 0
+        let number = 0
 
         internal init() {
         }
@@ -85,7 +104,47 @@ final class CustomInitDefaultTests: XCTestCase {
     }
   }
 
-  func testInitializedVar_InitializerWins() {
+  // FIXME: Exclusively applicable fix-its aren't testable: https://github.com/pointfreeco/swift-macro-testing/issues/14
+  func testInitializedLetCustomLabel() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(default: 42, label: "_") let number = 0
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(default: 42, label: "_") let number = 0
+              ┬───────────
+              ╰─ 🛑 @Init can't be applied to already initialized constant
+                 ✏️ Remove '@Init(default: 42, label: "_")'
+                 ✏️ Remove '= 0'
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct S {
+        let number = 0
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        let number = 0
+
+        internal init() {
+        }
+      }
+      """
+    }
+  }
+
+  // FIXME: Exclusively applicable fix-its aren't testable: https://github.com/pointfreeco/swift-macro-testing/issues/14
+  func testInitializedVar() {
     assertMacro {
       """
       @MemberwiseInit
@@ -93,16 +152,203 @@ final class CustomInitDefaultTests: XCTestCase {
         @Init(default: 42) var number = 0
       }
       """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(default: 42) var number = 0
+              ┬──────────
+              ╰─ 🛑 Custom 'default' can't be applied to already initialized variable
+                 ✏️ Remove '@Init(default: 42)'
+                 ✏️ Remove '= 0'
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct S {
+        var number = 0
+      }
+      """
     } expansion: {
       """
       struct S {
-        @Init(default: 42) var number = 0
+        var number = 0
 
         internal init(
           number: Int = 0
         ) {
           self.number = number
         }
+      }
+      """
+    }
+  }
+
+  // FIXME: Exclusively applicable fix-its aren't testable: https://github.com/pointfreeco/swift-macro-testing/issues/14
+  func testAttributedInitializedLet() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @Binding @Init(default: 42) let number = 0
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Binding @Init(default: 42) let number = 0
+                       ┬──────────
+                       ╰─ 🛑 @Init can't be applied to already initialized constant
+                          ✏️ Remove '@Init(default: 42)'
+                          ✏️ Remove '= 0'
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Binding let number = 0
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        @Binding let number = 0
+
+        internal init() {
+        }
+      }
+      """
+    }
+  }
+
+  // FIXME: Exclusively applicable fix-its aren't testable: https://github.com/pointfreeco/swift-macro-testing/issues/14
+  func testAttributedInitializedLet2() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @Binding @Init(default: T.q) let number = T.t
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Binding @Init(default: T.q) let number = T.t
+                       ┬───────────
+                       ╰─ 🛑 @Init can't be applied to already initialized constant
+                          ✏️ Remove '@Init(default: T.q)'
+                          ✏️ Remove '= T.t'
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Binding let number = T.t
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        @Binding let number = T.t
+
+        internal init() {
+        }
+      }
+      """
+    }
+  }
+
+  // FIXME: Exclusively applicable fix-its aren't testable: https://github.com/pointfreeco/swift-macro-testing/issues/14
+  func testAttributedInitializedVar() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @Binding @Init(default: T.q) var number = T.t
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Binding @Init(default: T.q) var number = T.t
+                       ┬───────────
+                       ╰─ 🛑 Custom 'default' can't be applied to already initialized variable
+                          ✏️ Remove 'default: T.q'
+                          ✏️ Remove '= T.t'
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Binding @Init(default: T.q) var number: <#Type#>
+      }
+      """
+    }
+  }
+
+  // FIXME: Exclusively applicable fix-its aren't testable: https://github.com/pointfreeco/swift-macro-testing/issues/14
+  func testAttributedInitializedVar2() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @Binding @Init(default: T.q) var number = T.t
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Binding @Init(default: T.q) var number = T.t
+                       ┬───────────
+                       ╰─ 🛑 Custom 'default' can't be applied to already initialized variable
+                          ✏️ Remove 'default: T.q'
+                          ✏️ Remove '= T.t'
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Binding @Init(default: T.q) var number: <#Type#>
+      }
+      """
+    }
+  }
+
+  // FIXME: Exclusively applicable fix-its aren't testable: https://github.com/pointfreeco/swift-macro-testing/issues/14
+  // TODO: This test doesn't fit perfectly here because it touches on label
+  func testInitializedVarCustomLabel() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(default: 42, label: "_") var number = 0
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(default: 42, label: "_") var number = 0
+              ┬───────────
+              ╰─ 🛑 Custom 'default' can't be applied to already initialized variable
+                 ✏️ Remove 'default: 42'
+                 ✏️ Remove '= 0'
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(label: "_") 
       }
       """
     }
@@ -123,6 +369,28 @@ final class CustomInitDefaultTests: XCTestCase {
         @Init(default: 42) let x, y: Int
               ┬──────────
               ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
+                 ✏️ Remove '@Init(default: 42)'
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct S {
+        let x, y: Int
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        let x, y: Int
+
+        internal init(
+          x: Int,
+          y: Int
+        ) {
+          self.x = x
+          self.y = y
+        }
       }
       """
     }
@@ -157,6 +425,28 @@ final class CustomInitDefaultTests: XCTestCase {
         @Init(default: 42) var x, y: Int
               ┬──────────
               ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
+                 ✏️ Remove '@Init(default: 42)'
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct S {
+        var x, y: Int
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        var x, y: Int
+
+        internal init(
+          x: Int,
+          y: Int
+        ) {
+          self.x = x
+          self.y = y
+        }
       }
       """
     }
@@ -191,6 +481,26 @@ final class CustomInitDefaultTests: XCTestCase {
         @Init(default: 42) let x = 0, y: Int
               ┬──────────
               ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
+                 ✏️ Remove '@Init(default: 42)'
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct S {
+        let x = 0, y: Int
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        let x = 0, y: Int
+
+        internal init(
+          y: Int
+        ) {
+          self.y = y
+        }
       }
       """
     }
@@ -223,6 +533,28 @@ final class CustomInitDefaultTests: XCTestCase {
         @Init(default: 42) var x = 0, y: Int
               ┬──────────
               ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
+                 ✏️ Remove '@Init(default: 42)'
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct S {
+        var x = 0, y: Int
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        var x = 0, y: Int
+
+        internal init(
+          x: Int = 0,
+          y: Int
+        ) {
+          self.x = x
+          self.y = y
+        }
       }
       """
     }
@@ -242,7 +574,7 @@ final class CustomInitDefaultTests: XCTestCase {
     //      """
   }
 
-  func testLetWithRaggedBindings_SucceedsWithInvalidCode() {
+  func testLetWithRaggedBindings() {
     assertMacro {
       """
       @MemberwiseInit
@@ -257,6 +589,28 @@ final class CustomInitDefaultTests: XCTestCase {
         @Init(default: 42) let x: Int, isOn: Bool
               ┬──────────
               ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
+                 ✏️ Remove '@Init(default: 42)'
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct S {
+        let x: Int, isOn: Bool
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        let x: Int, isOn: Bool
+
+        internal init(
+          x: Int,
+          isOn: Bool
+        ) {
+          self.x = x
+          self.isOn = isOn
+        }
       }
       """
     }

--- a/Tests/MemberwiseInitTests/CustomInitRawTests.swift
+++ b/Tests/MemberwiseInitTests/CustomInitRawTests.swift
@@ -63,6 +63,45 @@ final class CustomInitRawTests: XCTestCase {
     }
   }
 
+  // FIXME: Exclusively applicable fix-its aren't testable: https://github.com/pointfreeco/swift-macro-testing/issues/14
+  func testDefaultOnInitializedLet() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @InitRaw(default: 42) let number = 0
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct S {
+        @InitRaw(default: 42) let number = 0
+                 ┬──────────
+                 ╰─ 🛑 @InitRaw can't be applied to already initialized constant
+                    ✏️ Remove '@InitRaw(default: 42)'
+                    ✏️ Remove '= 0'
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct S {
+        let number = 0
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        let number = 0
+
+        internal init() {
+        }
+      }
+      """
+    }
+  }
+
   func testType() {
     assertMacro {
       """

--- a/Tests/MemberwiseInitTests/CustomInitTests.swift
+++ b/Tests/MemberwiseInitTests/CustomInitTests.swift
@@ -1,0 +1,210 @@
+import MacroTesting
+import MemberwiseInitMacros
+import XCTest
+
+final class CustomInitTests: XCTestCase {
+  override func invokeTest() {
+    // NB: Waiting for swift-macro-testing PR to support explicit indentationWidth: https://github.com/pointfreeco/swift-macro-testing/pull/8
+    withMacroTesting(
+      //indentationWidth: .spaces(2),
+      macros: [
+        "MemberwiseInit": MemberwiseInitMacro.self,
+        "InitRaw": InitMacro.self,
+      ]
+    ) {
+      super.invokeTest()
+    }
+  }
+
+  // FIXME: Exclusively applicable fix-its aren't testable: https://github.com/pointfreeco/swift-macro-testing/issues/14
+  // TODO: For 1.0, diagnostic error on nonsensical @Init
+  func testInitializedLet() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init let number = 42
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init let number = 42
+        ┬────
+        ╰─ ⚠️ @Init can't be applied to already initialized constant
+           ✏️ Remove '@Init'
+           ✏️ Remove '= 42'
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct S {
+        let number = 42
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        let number = 42
+
+        internal init() {
+        }
+      }
+      """
+    }
+  }
+
+  // TODO: For 1.0, diagnostic error on nonsensical @Init. While getter-only computed properties are
+  // nonsensical, setter computed properties could be allowed, and perhaps also computed properties with init accessor?
+  // TODO: For 0.3.0, diagnostic warning on nonsensical @Init?
+  func testComputedProperty() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        var number: Int
+        @Init var computed: Int { number * 2 }
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        var number: Int
+        @Init var computed: Int { number * 2 }
+
+        internal init(
+          number: Int
+        ) {
+          self.number = number
+        }
+      }
+      """
+    }
+  }
+
+  // TODO: For 1.0, diagnostic error on nonsensical @Init
+  func testStaticProperty() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init static var staticNumber: Int
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init static var staticNumber: Int
+              ┬─────
+              ╰─ ⚠️ @Init can't be applied to 'static' members
+                 ✏️ Remove '@Init'
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct S {
+        static var staticNumber: Int
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        static var staticNumber: Int
+
+        internal init() {
+        }
+      }
+      """
+    }
+  }
+
+  // TODO: For 1.0, diagnostic error on nonsensical @Init
+  func testLazyProperty() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(default: 0) lazy var lazyNumber: Int = {
+          return 2 * 2
+        }()
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct S {
+        @Init(default: 0) lazy var lazyNumber: Int = {
+                          ┬───
+                          ╰─ ⚠️ @Init can't be applied to 'lazy' members
+                             ✏️ Remove '@Init(default: 0)'
+          return 2 * 2
+        }()
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct S {
+        lazy var lazyNumber: Int = {
+          return 2 * 2
+        }()
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        lazy var lazyNumber: Int = {
+          return 2 * 2
+        }()
+
+        internal init() {
+        }
+      }
+      """
+    }
+  }
+
+  // NB: 'lazy static' is redundant and a compiler error: "'lazy' cannot be used on an already-lazy
+  // global". Since the fix is to "Remove 'lazy '", @MemberwiseInit emits its diagnostic on
+  // 'static' which is still a mistake to apply @Init to.
+  func testLazyStaticProperty() {
+    assertMacro {
+      """
+      @MemberwiseInit
+      struct B {
+        @Init lazy static var value = 0
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct B {
+        @Init lazy static var value = 0
+                   ┬─────
+                   ╰─ ⚠️ @Init can't be applied to 'static' members
+                      ✏️ Remove '@Init'
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct B {
+        lazy static var value = 0
+      }
+      """
+    } expansion: {
+      """
+      struct B {
+        lazy static var value = 0
+
+        internal init() {
+        }
+      }
+      """
+    }
+  }
+}

--- a/Tests/MemberwiseInitTests/LayeredDiagnosticsTests.swift
+++ b/Tests/MemberwiseInitTests/LayeredDiagnosticsTests.swift
@@ -53,6 +53,7 @@ final class LayeredDiagnosticsTests: XCTestCase {
               │           ╰─ 🛑 Custom 'label' can't be applied to multiple bindings
               ┬──────────
               ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
+                 ✏️ Remove 'default: 0'
       }
       """
     }
@@ -77,6 +78,7 @@ final class LayeredDiagnosticsTests: XCTestCase {
               │           ╰─ 🛑 Custom 'label' can't be applied to multiple bindings
               ┬──────────
               ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
+                 ✏️ Remove 'default: 0'
       }
       """
     }

--- a/Tests/MemberwiseInitTests/MemberwiseInitTests.swift
+++ b/Tests/MemberwiseInitTests/MemberwiseInitTests.swift
@@ -129,13 +129,31 @@ final class MemberwiseInitTests: XCTestCase {
     }
   }
 
-  // TODO: Emit diagnostic on "@Init" when applied nonsensically.
-  func testInitOnLetWithInitializer_IsIgnored() {
+  // FIXME: Exclusively applicable fix-its aren't testable: https://github.com/pointfreeco/swift-macro-testing/issues/14
+  func testInitOnLetWithInitializer_WarnsAndIgnored() {
     assertMacro {
       """
       @MemberwiseInit
       struct Earth {
         @Init let name = "Earth"
+      }
+      """
+    } diagnostics: {
+      """
+      @MemberwiseInit
+      struct Earth {
+        @Init let name = "Earth"
+        ┬────
+        ╰─ ⚠️ @Init can't be applied to already initialized constant
+           ✏️ Remove '@Init'
+           ✏️ Remove '= "Earth"'
+      }
+      """
+    } fixes: {
+      """
+      @MemberwiseInit
+      struct Earth {
+        let name = "Earth"
       }
       """
     } expansion: {


### PR DESCRIPTION
Also, add several diagnostics and fix-its:

```
* ⚠️ @Init can't be applied to already initialized constant
  * ✏️ Remove '@Init'
  * ✏️ Remove '= 42'

* 🛑 @Init can't be applied to already initialized constant
  * ✏️ Remove '@Init(default: 0)'
  * ✏️ Remove '= 42'

* 🛑 Custom 'default' can't be applied to already initialized variable
  * ✏️ Remove 'default: 0'
  * ✏️ Remove '= 42'

* ⚠️ @Init can't be applied to 'static' members
  * ✏️ Remove '@Init'

* 🛑 Custom 'default' can't be applied to multiple bindings
  * ✏️ Remove '@Init(default: 42)'
```