### PR TITLE
Access leak fix its

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,30 +1,21 @@
 {
   "pins" : [
     {
-      "identity" : "swift-macro-testing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-macro-testing",
-      "state" : {
-        "revision" : "10dcef36314ddfea6f60442169b0b320204cbd35",
-        "version" : "0.2.2"
-      }
-    },
-    {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "4862d48562483d274a2ac7522d905c9237a31a48",
-        "version" : "1.15.0"
+        "revision" : "59b663f68e69f27a87b45de48cb63264b8194605",
+        "version" : "1.15.1"
       }
     },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax",
+      "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b",
-        "version" : "509.0.0"
+        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
+        "version" : "509.0.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -22,12 +22,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    //    .package(
-    //      url: "https://github.com/gohanlon/swift-macro-testing",
-    //      branch: "explicit-indentation-width"
-    //    ),
-    // TODO: w/f https://github.com/pointfreeco/swift-macro-testing/pull/8
-    .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.1"),
+    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.15.0"),
     .package(url: "https://github.com/apple/swift-syntax", from: "509.0.0"),
   ],
   targets: [
@@ -50,8 +45,25 @@ let package = Package(
       name: "MemberwiseInitTests",
       dependencies: [
         "MemberwiseInitMacros",
-        .product(name: "MacroTesting", package: "swift-macro-testing"),
+        "MacroTesting",
         .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+      ]
+    ),
+    .target(
+      name: "MacroTesting",
+      dependencies: [
+        .product(name: "InlineSnapshotTesting", package: "swift-snapshot-testing"),
+        .product(name: "SwiftDiagnostics", package: "swift-syntax"),
+        .product(name: "SwiftOperators", package: "swift-syntax"),
+        .product(name: "SwiftParserDiagnostics", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+      ]
+    ),
+    .testTarget(
+      name: "MacroTestingTests",
+      dependencies: [
+        "MacroTesting"
       ]
     ),
   ]

--- a/Sources/MacroTesting/AssertMacro.swift
+++ b/Sources/MacroTesting/AssertMacro.swift
@@ -1,0 +1,784 @@
+import InlineSnapshotTesting
+import SwiftDiagnostics
+import SwiftOperators
+import SwiftParser
+import SwiftParserDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
+import XCTest
+
+//let compilableUsages = {
+//  assertMacro { "" }
+//  assertMacro { "" } expansion: { "" }
+//  assertMacro { "" } expansion: { "" } diagnostics: { "" }
+//  assertMacro { "" } expansion: { "" } diagnostics: { "" } fixes: { "" }
+//  assertMacro { "" } diagnostics: { "" }
+//  assertMacro { "" } diagnostics: { "" } fixes: { "" }
+//
+//  // technically allowed by signature
+//  assertMacro { "" } fixes: { "" }
+//
+//  // old usage
+//  assertMacro { "" } diagnostics: { "" } expansion: { "" }
+//  assertMacro { "" } fixes: { "" } expansion: { "" }
+//  assertMacro { "" } diagnostics: { "" } fixes: { "" } expansion: { "" }
+//
+//  return false
+//}()
+
+// Allow previous usage to compile during migration.
+// Fail any test where `expansion` is given after `diagnostics`/`fixes`.
+@_disfavoredOverload
+public func assertMacro(
+  _ macros: [String: Macro.Type]? = nil,
+  indentationWidth: Trivia? = nil,
+  record isRecording: Bool? = nil,
+  of originalSource: () throws -> String,
+  diagnostics diagnosedSource: (() -> String)? = nil,
+  fixes fixedSource: (() -> String)? = nil,
+  expansion expandedSource: (() -> String)? = nil,
+  file: StaticString = #filePath,
+  function: StaticString = #function,
+  line: UInt = #line,
+  column: UInt = #column
+) {
+  if expandedSource != nil,
+    diagnosedSource != nil || fixedSource != nil
+  {
+    XCTFail("`expansion` must come before both `diagnostics` and `fixes`", file: file, line: line)
+    return
+  }
+  assertMacro(
+    macros,
+    indentationWidth: indentationWidth,
+    record: isRecording,
+    of: originalSource,
+    expansion: expandedSource,
+    diagnostics: diagnosedSource,
+    fixes: fixedSource,
+    file: file,
+    function: function,
+    line: line,
+    column: column
+  )
+}
+
+/// Asserts that a given Swift source string matches an expected string with all macros expanded.
+///
+/// To write a macro assertion, you simply pass the mapping of macros to expand along with the
+/// source code that should be expanded:
+///
+/// ```swift
+/// func testMacro() {
+///   assertMacro(["stringify": StringifyMacro.self]) {
+///     """
+///     #stringify(a + b)
+///     """
+///   }
+/// }
+/// ```
+///
+/// When this test is run, the result of the expansion is automatically written to the test file,
+/// inlined, as a trailing argument:
+///
+/// ```swift
+/// func testMacro() {
+///   assertMacro(["stringify": StringifyMacro.self]) {
+///     """
+///     #stringify(a + b)
+///     """
+///   } expansion: {
+///     """
+///     (a + b, "a + b")
+///     """
+///   }
+/// }
+/// ```
+///
+/// If the expansion fails, diagnostics are inlined instead:
+///
+/// ```swift
+/// assertMacro(["MetaEnum": MetaEnumMacro.self]) {
+///   """
+///   @MetaEnum struct Cell {
+///     let integer: Int
+///     let text: String
+///     let boolean: Bool
+///   }
+///   """
+/// } diagnostics: {
+///   """
+///   @MetaEnum struct Cell {
+///   ┬────────
+///   ╰─ 🛑 '@MetaEnum' can only be attached to an enum, not a struct
+///     let integer: Int
+///     let text: String
+///     let boolean: Bool
+///   }
+///   """
+/// }
+/// ```
+///
+/// > Tip: Use ``withMacroTesting(indentationWidth:isRecording:macros:operation:)-5id9j`` in your
+/// > test case's `invokeTest` to avoid the repetitive work of passing the macro mapping to every
+/// > `assertMacro`:
+/// >
+/// > ```swift
+/// > override func invokeTest() {
+/// >   // By wrapping each test with macro testing configuration...
+/// >   withMacroTesting(macros: ["stringify": StringifyMacro.self]) {
+/// >     super.invokeTest()
+/// >   }
+/// > }
+/// >
+/// > func testMacro() {
+/// >   assertMacro {  // ...we can omit it from the assertion.
+/// >     """
+/// >     #stringify(a + b)
+/// >     """
+/// >   } expansion: {
+/// >     """
+/// >     (a + b, "a + b")
+/// >     """
+/// >   }
+/// > }
+/// > ```
+///
+/// - Parameters:
+///   - macros: The macros to expand in the original source string. Required, either implicitly via
+///     ``withMacroTesting(indentationWidth:isRecording:macros:operation:)-5id9j``, or explicitly
+///     via this parameter.
+///   - applyFixIts: Whether to assert the application of fix-its. Defaults to `true`.
+///   - indentationWidth: The `Trivia` for setting indentation during macro expansion
+///     (e.g., `.spaces(2)`). Defaults to the original source's indentation if unspecified. If the
+///     original source lacks indentation, it defaults to `.spaces(4)`.
+///   - isRecording: Always records new snapshots when enabled.
+///   - originalSource: A string of Swift source code.
+///   - diagnosedSource: Swift source code annotated with expected diagnostics.
+///   - fixedSource: Swift source code with expected fix-its applied.
+///   - expandedSource: Expected Swift source string with macros expanded.
+///   - file: The file where the assertion occurs. The default is the filename of the test case
+///     where you call this function.
+///   - function: The function where the assertion occurs. The default is the name of the test
+///     method where you call this function.
+///   - line: The line where the assertion occurs. The default is the line number where you call
+///     this function.
+///   - column: The column where the assertion occurs. The default is the column where you call this
+///     function.
+public func assertMacro(
+  _ macros: [String: Macro.Type]? = nil,
+  applyFixIts: Bool = true,
+  indentationWidth: Trivia? = nil,
+  record isRecording: Bool? = nil,
+  of originalSource: () throws -> String,
+  expansion expandedSource: (() -> String)? = nil,
+  diagnostics diagnosedSource: (() -> String)? = nil,
+  fixes fixedSource: (() -> String)? = nil,
+  file: StaticString = #filePath,
+  function: StaticString = #function,
+  line: UInt = #line,
+  column: UInt = #column
+) {
+  let macros = macros ?? MacroTestingConfiguration.current.macros
+  guard !macros.isEmpty else {
+    XCTFail(
+      """
+      No macros configured for this assertion. Pass a mapping to this function, e.g.:
+
+          assertMacro(["stringify": StringifyMacro.self]) { … }
+
+      Or wrap your assertion using 'withMacroTesting', e.g. in 'invokeTest':
+
+          class StringifyMacroTests: XCTestCase {
+            override func invokeTest() {
+              withMacroTesting(macros: ["stringify": StringifyMacro.self]) {
+                super.invokeTest()
+              }
+            }
+            …
+          }
+      """,
+      file: file,
+      line: line
+    )
+    return
+  }
+
+  let wasRecording = SnapshotTesting.isRecording
+  SnapshotTesting.isRecording = isRecording ?? MacroTestingConfiguration.current.isRecording
+  defer { SnapshotTesting.isRecording = wasRecording }
+
+  do {
+    var origSourceFile = Parser.parse(source: try originalSource())
+    if let foldedSourceFile = try OperatorTable.standardOperators.foldAll(origSourceFile).as(
+      SourceFileSyntax.self
+    ) {
+      origSourceFile = foldedSourceFile
+    }
+
+    let origDiagnostics = ParseDiagnosticsGenerator.diagnostics(for: origSourceFile)
+    let indentationWidth =
+      indentationWidth
+      ?? MacroTestingConfiguration.current.indentationWidth
+      ?? Trivia(
+        stringLiteral: String(
+          SourceLocationConverter(fileName: "-", tree: origSourceFile).sourceLines
+            .first(where: { $0.first?.isWhitespace == true && $0 != "\n" })?
+            .prefix(while: { $0.isWhitespace })
+            ?? "    "
+        )
+      )
+
+    let context = BasicMacroExpansionContext(
+      sourceFiles: [
+        origSourceFile: .init(moduleName: "TestModule", fullFilePath: "Test.swift")
+      ]
+    )
+    let expandedSourceFile = origSourceFile.expand(
+      macros: macros,
+      in: context,
+      indentationWidth: indentationWidth
+    )
+
+    var offset = 0
+
+    func anchor(_ diag: Diagnostic) -> Diagnostic {
+      let location = context.location(for: diag.position, anchoredAt: diag.node, fileName: "")
+      return Diagnostic(
+        node: diag.node,
+        position: AbsolutePosition(utf8Offset: location.offset),
+        message: diag.diagMessage,
+        highlights: diag.highlights,
+        notes: diag.notes,
+        fixIts: diag.fixIts
+      )
+    }
+
+    // TODO: write a test where didExpand returns false
+    // For now, covered in MemberwiseInitTests.testAppliedToEnum_FailsWithDiagnostic
+    var didExpand: Bool {
+      let origSourceWithMacroAttributesRemoved = MacroTesting.AttributeRemover509(
+        removingWhere: {
+          guard let name = $0.attributeName.as(IdentifierTypeSyntax.self)?.name.text
+          else { return false }
+          return macros.keys.contains(name)
+        }
+      ).rewrite(origSourceFile)
+
+      return expandedSourceFile.description.trimmingCharacters(in: .newlines)
+        != origSourceWithMacroAttributesRemoved.description.trimmingCharacters(in: .newlines)
+    }
+
+    if didExpand {
+      offset += 1
+      assertInlineSnapshot(
+        of: expandedSourceFile.description.trimmingCharacters(in: .newlines),
+        as: ._lines,
+        message: """
+          Expanded output (\(newPrefix)) differed from expected output (\(oldPrefix)). \
+          Difference: …
+          """,
+        syntaxDescriptor: InlineSnapshotSyntaxDescriptor(
+          deprecatedTrailingClosureLabels: ["matches"],
+          trailingClosureLabel: "expansion",
+          trailingClosureOffset: offset
+        ),
+        matches: expandedSource,
+        file: file,
+        function: function,
+        line: line,
+        column: column
+      )
+    } else if expandedSource != nil {
+      offset += 1
+      InlineSnapshotSyntaxDescriptor(
+        trailingClosureLabel: "expansion",
+        trailingClosureOffset: offset
+      )
+      .fail(
+        "Expected macro expansion, but there was none",
+        file: file,
+        line: line,
+        column: column
+      )
+    }
+
+    let allDiagnostics: [Diagnostic] = origDiagnostics + context.diagnostics
+    if !allDiagnostics.isEmpty || diagnosedSource != nil {
+      offset += 1
+
+      let converter = SourceLocationConverter(fileName: "-", tree: origSourceFile)
+      let lineCount = converter.location(for: origSourceFile.endPosition).line
+      let diagnostics =
+        DiagnosticsFormatter
+        .annotatedSource(
+          tree: origSourceFile,
+          diags: allDiagnostics.map(anchor),
+          context: context,
+          contextSize: lineCount
+        )
+        .description
+        .replacingOccurrences(of: #"(^|\n) *\d* +│ "#, with: "$1", options: .regularExpression)
+        .trimmingCharacters(in: .newlines)
+
+      assertInlineSnapshot(
+        of: diagnostics,
+        as: ._lines,
+        message: """
+          Diagnostic output (\(newPrefix)) differed from expected output (\(oldPrefix)). \
+          Difference: …
+          """,
+        syntaxDescriptor: InlineSnapshotSyntaxDescriptor(
+          deprecatedTrailingClosureLabels: ["matches"],
+          trailingClosureLabel: "diagnostics",
+          trailingClosureOffset: offset
+        ),
+        matches: diagnosedSource,
+        file: file,
+        function: function,
+        line: line,
+        column: column
+      )
+    } else if diagnosedSource != nil {
+      offset += 1
+      InlineSnapshotSyntaxDescriptor(
+        trailingClosureLabel: "diagnostics",
+        trailingClosureOffset: offset
+      )
+      .fail(
+        "Expected diagnostics, but there were none",
+        file: file,
+        line: line,
+        column: column
+      )
+    }
+
+    if applyFixIts && !allDiagnostics.isEmpty
+      && allDiagnostics.contains(where: { !$0.fixIts.isEmpty })
+    {
+      offset += 1
+
+      let diagnostics = allDiagnostics.filter { !$0.fixIts.isEmpty }
+
+      // NB: Only one of the fix-its can be applied at a time--they can be exclustive, e.g. two
+      // options for how to resolve an issue.
+      var fixedSourceLines = [String]()
+      for (diagnosticIndex, diagnostic) in diagnostics.enumerated() {
+        let diagnosticsString =
+          DiagnosticsFormatter
+          .annotatedSource(
+            tree: origSourceFile,
+            diags: [diagnostic].map(anchor),
+            context: context,
+            contextSize: 0
+          )
+          .description
+          .replacingOccurrences(of: #"(^|\n) *\d* +│ "#, with: "$1", options: .regularExpression)
+          .trimmingCharacters(in: .newlines)
+
+        let lines = diagnosticsString.split(separator: "\n")
+        let extraLeadingWhitespace = lines.first?.prefix(while: \.isWhitespace).count ?? 0
+        var fixIts = diagnostic.fixIts
+        for (lineNumber, line) in lines.enumerated() {
+          if line.first(where: { !$0.isWhitespace }) != "✏️" {
+            let line = String(line.dropFirst(extraLeadingWhitespace))
+
+            if diagnosticIndex > 0 && lineNumber == 0 {
+              fixedSourceLines.append("")
+            }
+            fixedSourceLines.append(line)
+            continue
+          }
+          let line = String(line.drop(while: \.isWhitespace))
+
+          let fixIt = fixIts.removeFirst()
+
+          let edits = fixIt.changes
+            .map { $0.edit(in: context) }
+
+          var fixedSourceFile = Parser.parse(
+            source: FixItApplier.apply(
+              edits: edits,
+              to: origSourceFile
+            )
+            .description
+          )
+
+          if let foldedSourceFile = try OperatorTable.standardOperators.foldAll(fixedSourceFile)
+            .as(SourceFileSyntax.self)
+          {
+            fixedSourceFile = foldedSourceFile
+          }
+
+          fixedSourceLines.append("")
+          fixedSourceLines.append(line)
+          fixedSourceLines.append(fixedSourceFile.description)
+        }
+      }
+
+      assertInlineSnapshot(
+        of: fixedSourceLines.joined(separator: "\n").trimmingCharacters(in: .newlines),
+        as: ._lines,
+        message: """
+          Fixed output (\(newPrefix)) differed from expected output (\(oldPrefix)). \
+          Difference: …
+          """,
+        syntaxDescriptor: InlineSnapshotSyntaxDescriptor(
+          trailingClosureLabel: "fixes",
+          trailingClosureOffset: offset
+        ),
+        matches: fixedSource,
+        file: file,
+        function: function,
+        line: line,
+        column: column
+      )
+    } else if fixedSource != nil {
+      offset += 1
+      InlineSnapshotSyntaxDescriptor(
+        trailingClosureLabel: "fixes",
+        trailingClosureOffset: offset
+      )
+      .fail(
+        "Expected fix-its, but there were none",
+        file: file,
+        line: line,
+        column: column
+      )
+    }
+  } catch {
+    XCTFail("Threw error: \(error)", file: file, line: line)
+  }
+}
+
+// From: https://github.com/apple/swift-syntax/blob/d647052/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+extension FixIt.Change {
+  /// Returns the edit for this change, translating positions from detached nodes
+  /// to the corresponding locations in the original source file based on
+  /// `expansionContext`.
+  ///
+  /// - SeeAlso: `FixIt.Change.edit`
+  fileprivate func edit(in expansionContext: BasicMacroExpansionContext) -> SourceEdit {
+    switch self {
+    case .replace(let oldNode, let newNode):
+      let start = expansionContext.position(of: oldNode.position, anchoredAt: oldNode)
+      let end = expansionContext.position(of: oldNode.endPosition, anchoredAt: oldNode)
+      return SourceEdit(
+        range: start..<end,
+        replacement: newNode.description
+      )
+
+    case .replaceLeadingTrivia(let token, let newTrivia):
+      let start = expansionContext.position(of: token.position, anchoredAt: token)
+      let end = expansionContext.position(
+        of: token.positionAfterSkippingLeadingTrivia, anchoredAt: token)
+      return SourceEdit(
+        range: start..<end,
+        replacement: newTrivia.description
+      )
+
+    case .replaceTrailingTrivia(let token, let newTrivia):
+      let start = expansionContext.position(
+        of: token.endPositionBeforeTrailingTrivia, anchoredAt: token)
+      let end = expansionContext.position(of: token.endPosition, anchoredAt: token)
+      return SourceEdit(
+        range: start..<end,
+        replacement: newTrivia.description
+      )
+    }
+  }
+}
+
+// From: https://github.com/apple/swift-syntax/blob/d647052/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+extension BasicMacroExpansionContext {
+  /// Translates a position from a detached node to the corresponding position
+  /// in the original source file.
+  fileprivate func position(
+    of position: AbsolutePosition,
+    anchoredAt node: some SyntaxProtocol
+  ) -> AbsolutePosition {
+    let location = self.location(for: position, anchoredAt: Syntax(node), fileName: "")
+    return AbsolutePosition(utf8Offset: location.offset)
+  }
+}
+
+/// Asserts that a given Swift source string matches an expected string with all macros expanded.
+///
+/// See ``assertMacro(_:indentationWidth:record:of:diagnostics:fixes:expansion:file:function:line:column:)-pkfi``
+/// for more details.
+///
+/// - Parameters:
+///   - macros: The macros to expand in the original source string. Required, either implicitly via
+///     ``withMacroTesting(indentationWidth:isRecording:macros:operation:)-5id9j``, or explicitly
+///     via this parameter.
+///   - indentationWidth: The `Trivia` for setting indentation during macro expansion
+///     (e.g., `.spaces(2)`). Defaults to the original source's indentation if unspecified. If the
+///     original source lacks indentation, it defaults to `.spaces(4)`.
+///   - isRecording: Always records new snapshots when enabled.
+///   - originalSource: A string of Swift source code.
+///   - diagnosedSource: Swift source code annotated with expected diagnostics.
+///   - fixedSource: Swift source code with expected fix-its applied.
+///   - expandedSource: Expected Swift source string with macros expanded.
+///   - file: The file where the assertion occurs. The default is the filename of the test case
+///     where you call this function.
+///   - function: The function where the assertion occurs. The default is the name of the test
+///     method where you call this function.
+///   - line: The line where the assertion occurs. The default is the line number where you call
+///     this function.
+///   - column: The column where the assertion occurs. The default is the column where you call this
+///     function.
+public func assertMacro(
+  _ macros: [Macro.Type],
+  indentationWidth: Trivia? = nil,
+  record isRecording: Bool? = nil,
+  of originalSource: () throws -> String,
+  expansion expandedSource: (() -> String)? = nil,
+  diagnostics diagnosedSource: (() -> String)? = nil,
+  fixes fixedSource: (() -> String)? = nil,
+  file: StaticString = #filePath,
+  function: StaticString = #function,
+  line: UInt = #line,
+  column: UInt = #column
+) {
+  assertMacro(
+    Dictionary(macros: macros),
+    indentationWidth: indentationWidth,
+    record: isRecording,
+    of: originalSource,
+    expansion: expandedSource,
+    diagnostics: diagnosedSource,
+    fixes: fixedSource,
+    file: file,
+    function: function,
+    line: line,
+    column: column
+  )
+}
+
+/// Customizes `assertMacro` for the duration of an operation.
+///
+/// Use this operation to customize how the `assertMacro` behaves in a test. It is most convenient
+/// to use this tool to wrap `invokeTest` in a `XCTestCase` subclass so that the configuration
+/// applies to every test method.
+///
+/// For example, to specify which macros will be expanded during an assertion for an entire test
+/// case you can do the following:
+///
+/// ```swift
+/// class StringifyTests: XCTestCase {
+///   override func invokeTest() {
+///     withMacroTesting(macros: [StringifyMacro.self]) {
+///       super.invokeTest()
+///     }
+///   }
+/// }
+/// ```
+///
+/// And to re-record all macro expansions in a test case you can do the following:
+///
+/// ```swift
+/// class StringifyTests: XCTestCase {
+///   override func invokeTest() {
+///     withMacroTesting(isRecording: true, macros: [StringifyMacro.self]) {
+///       super.invokeTest()
+///     }
+///   }
+/// }
+/// ```
+///
+/// - Parameters:
+///   - indentationWidth: The `Trivia` for setting indentation during macro expansion
+///     (e.g., `.spaces(2)`). Defaults to the original source's indentation if unspecified. If the
+///     original source lacks indentation, it defaults to `.spaces(4)`.
+///   - isRecording: Determines if a new macro expansion will be recorded.
+///   - macros: Specifies the macros to be expanded in the input Swift source string.
+///   - operation: The operation to run with the configuration updated.
+public func withMacroTesting<R>(
+  indentationWidth: Trivia? = nil,
+  isRecording: Bool? = nil,
+  macros: [String: Macro.Type]? = nil,
+  operation: () async throws -> R
+) async rethrows {
+  var configuration = MacroTestingConfiguration.current
+  if let indentationWidth = indentationWidth { configuration.indentationWidth = indentationWidth }
+  if let isRecording = isRecording { configuration.isRecording = isRecording }
+  if let macros = macros { configuration.macros = macros }
+  try await MacroTestingConfiguration.$current.withValue(configuration) {
+    try await operation()
+  }
+}
+
+/// Customizes `assertMacro` for the duration of an operation.
+///
+/// See ``withMacroTesting(indentationWidth:isRecording:macros:operation:)-5id9j`` for
+/// more details.
+///
+/// - Parameters:
+///   - indentationWidth: The `Trivia` for setting indentation during macro expansion
+///     (e.g., `.spaces(2)`). Defaults to the original source's indentation if unspecified. If the
+///     original source lacks indentation, it defaults to `.spaces(4)`.
+///   - isRecording: Determines if a new macro expansion will be recorded.
+///   - macros: Specifies the macros to be expanded in the input Swift source string.
+///   - operation: The operation to run with the configuration updated.
+public func withMacroTesting<R>(
+  indentationWidth: Trivia? = nil,
+  isRecording: Bool? = nil,
+  macros: [String: Macro.Type]? = nil,
+  operation: () throws -> R
+) rethrows {
+  var configuration = MacroTestingConfiguration.current
+  if let indentationWidth = indentationWidth { configuration.indentationWidth = indentationWidth }
+  if let isRecording = isRecording { configuration.isRecording = isRecording }
+  if let macros = macros { configuration.macros = macros }
+  try MacroTestingConfiguration.$current.withValue(configuration) {
+    try operation()
+  }
+}
+
+/// Customizes `assertMacro` for the duration of an operation.
+///
+/// See ``withMacroTesting(indentationWidth:isRecording:macros:operation:)-5id9j`` for
+/// more details.
+///
+/// - Parameters:
+///   - indentationWidth: The `Trivia` for setting indentation during macro expansion
+///     (e.g., `.spaces(2)`). Defaults to the original source's indentation if unspecified. If the
+///     original source lacks indentation, it defaults to `.spaces(4)`.
+///   - isRecording: Determines if a new macro expansion will be recorded.
+///   - macros: Specifies the macros to be expanded in the input Swift source string.
+///   - operation: The operation to run with the configuration updated.
+public func withMacroTesting<R>(
+  indentationWidth: Trivia? = nil,
+  isRecording: Bool? = nil,
+  macros: [Macro.Type],
+  operation: () async throws -> R
+) async rethrows {
+  try await withMacroTesting(
+    indentationWidth: indentationWidth,
+    isRecording: isRecording,
+    macros: Dictionary(macros: macros),
+    operation: operation
+  )
+}
+
+/// Customizes `assertMacro` for the duration of an operation.
+///
+/// See ``withMacroTesting(indentationWidth:isRecording:macros:operation:)-5id9j`` for
+/// more details.
+///
+/// - Parameters:
+///   - indentationWidth: The `Trivia` for setting indentation during macro expansion
+///     (e.g., `.spaces(2)`). Defaults to the original source's indentation if unspecified. If the
+///     original source lacks indentation, it defaults to `.spaces(4)`.
+///   - isRecording: Determines if a new macro expansion will be recorded.
+///   - macros: Specifies the macros to be expanded in the input Swift source string.
+///   - operation: The operation to run with the configuration updated.
+public func withMacroTesting<R>(
+  indentationWidth: Trivia? = nil,
+  isRecording: Bool? = nil,
+  macros: [Macro.Type],
+  operation: () throws -> R
+) rethrows {
+  try withMacroTesting(
+    indentationWidth: indentationWidth,
+    isRecording: isRecording,
+    macros: Dictionary(macros: macros),
+    operation: operation
+  )
+}
+
+extension Snapshotting where Value == String, Format == String {
+  fileprivate static let _lines = Snapshotting(
+    pathExtension: "txt",
+    diffing: Diffing(
+      toData: { Data($0.utf8) },
+      fromData: { String(decoding: $0, as: UTF8.self) }
+    ) { old, new in
+      guard old != new else { return nil }
+
+      let newLines = new.split(separator: "\n", omittingEmptySubsequences: false)
+
+      let oldLines = old.split(separator: "\n", omittingEmptySubsequences: false)
+      let difference = newLines.difference(from: oldLines)
+
+      var result = ""
+
+      var insertions = [Int: Substring]()
+      var removals = [Int: Substring]()
+
+      for change in difference {
+        switch change {
+        case let .insert(offset, element, _):
+          insertions[offset] = element
+        case let .remove(offset, element, _):
+          removals[offset] = element
+        }
+      }
+
+      var oldLine = 0
+      var newLine = 0
+
+      while oldLine < oldLines.count || newLine < newLines.count {
+        if let removal = removals[oldLine] {
+          result += "\(oldPrefix) \(removal)\n"
+          oldLine += 1
+        } else if let insertion = insertions[newLine] {
+          result += "\(newPrefix) \(insertion)\n"
+          newLine += 1
+        } else {
+          result += "\(prefix) \(oldLines[oldLine])\n"
+          oldLine += 1
+          newLine += 1
+        }
+      }
+
+      let attachment = XCTAttachment(
+        data: Data(result.utf8),
+        uniformTypeIdentifier: "public.patch-file"
+      )
+      return (result, [attachment])
+    }
+  )
+}
+
+internal func macroName(className: String, isExpression: Bool) -> String {
+  var name =
+    className
+    .replacingOccurrences(of: "Macro$", with: "", options: .regularExpression)
+  if !name.isEmpty, isExpression {
+    var prefix = name.prefix(while: \.isUppercase)
+    if prefix.count > 1, name[prefix.endIndex...].first?.isLowercase == true {
+      prefix.removeLast()
+    }
+    name.replaceSubrange(prefix.startIndex..<prefix.endIndex, with: prefix.lowercased())
+  }
+  return name
+}
+
+struct MacroTestingConfiguration {
+  @TaskLocal static var current = Self()
+
+  var indentationWidth: Trivia? = nil
+  var isRecording = false
+  var macros: [String: Macro.Type] = [:]
+}
+
+extension Dictionary where Key == String, Value == Macro.Type {
+  init(macros: [Macro.Type]) {
+    self.init(
+      macros.map {
+        let name = macroName(
+          className: String(describing: $0),
+          isExpression: $0 is ExpressionMacro.Type
+        )
+        return (key: name, value: $0)
+      },
+      uniquingKeysWith: { _, rhs in rhs }
+    )
+  }
+}
+
+private let oldPrefix = "\u{2212}"
+private let newPrefix = "+"
+private let prefix = "\u{2007}"

--- a/Sources/MacroTesting/Internal/AttributeRemover509.swift
+++ b/Sources/MacroTesting/Internal/AttributeRemover509.swift
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// AttributeRemover is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+/// Removes attributes from a syntax tree while maintaining their surrounding trivia.
+class AttributeRemover509: SyntaxRewriter {
+  let predicate: (AttributeSyntax) -> Bool
+
+  var triviaToAttachToNextToken: Trivia = Trivia()
+
+  init(removingWhere predicate: @escaping (AttributeSyntax) -> Bool) {
+    self.predicate = predicate
+  }
+
+  override func visit(_ node: AttributeListSyntax) -> AttributeListSyntax {
+    var filteredAttributes: [AttributeListSyntax.Element] = []
+    for case .attribute(let attribute) in node {
+      if self.predicate(attribute) {
+        var leadingTrivia = node.leadingTrivia
+        if let lastNewline = leadingTrivia.pieces.lastIndex(where: { $0.isNewline }),
+          leadingTrivia.pieces[lastNewline...].allSatisfy(\.isWhitespace),
+          node.trailingTrivia.isEmpty,
+          node.nextToken(viewMode: .sourceAccurate)?.leadingTrivia.first?.isNewline ?? false
+        {
+          // If the attribute is on its own line based on the following conditions,
+          // remove the newline from it so we don’t end up with an empty line
+          //  - Trailing trivia ends with a newline followed by arbitrary number of spaces or tabs
+          //  - There is no trailing trivia and the next token starts on a new line
+          leadingTrivia = Trivia(pieces: leadingTrivia.pieces[..<lastNewline])
+        }
+        // Drop any spaces or tabs from the trailing trivia because there’s no
+        // more attribute they need to separate.
+        let trailingTrivia = Trivia(
+          pieces: attribute.trailingTrivia.drop(while: { $0.isSpaceOrTab }))
+        triviaToAttachToNextToken += leadingTrivia + trailingTrivia
+      } else {
+        filteredAttributes.append(.attribute(attribute))
+      }
+    }
+    return AttributeListSyntax(filteredAttributes)
+  }
+
+  override func visit(_ token: TokenSyntax) -> TokenSyntax {
+    if !triviaToAttachToNextToken.isEmpty {
+      defer { triviaToAttachToNextToken = Trivia() }
+      return token.with(\.leadingTrivia, triviaToAttachToNextToken + token.leadingTrivia)
+    } else {
+      return token
+    }
+  }
+}

--- a/Sources/MacroTesting/Internal/Deprecations.swift
+++ b/Sources/MacroTesting/Internal/Deprecations.swift
@@ -1,0 +1,104 @@
+//import InlineSnapshotTesting
+//import SwiftDiagnostics
+//import SwiftOperators
+//import SwiftParser
+//import SwiftParserDiagnostics
+//import SwiftSyntax
+//import SwiftSyntaxMacroExpansion
+//import SwiftSyntaxMacros
+//import XCTest
+//
+//// MARK: Deprecated after 0.1.0
+//
+//@available(*, deprecated, message: "Re-record this assertion")
+//public func assertMacro(
+//  _ macros: [String: Macro.Type]? = nil,
+//  record isRecording: Bool? = nil,
+//  of originalSource: () throws -> String,
+//  matches expandedOrDiagnosedSource: () -> String,
+//  file: StaticString = #filePath,
+//  function: StaticString = #function,
+//  line: UInt = #line,
+//  column: UInt = #column
+//) {
+//  guard isRecording ?? MacroTestingConfiguration.current.isRecording else {
+//    XCTFail("Re-record this assertion", file: file, line: line)
+//    return
+//  }
+//  assertMacro(
+//    macros,
+//    record: true,
+//    of: originalSource,
+//    file: file,
+//    function: function,
+//    line: line,
+//    column: column
+//  )
+//}
+//
+//@available(*, deprecated, message: "Re-record this assertion")
+//public func assertMacro(
+//  _ macros: [Macro.Type],
+//  record isRecording: Bool? = nil,
+//  of originalSource: () throws -> String,
+//  matches expandedOrDiagnosedSource: () -> String,
+//  file: StaticString = #filePath,
+//  function: StaticString = #function,
+//  line: UInt = #line,
+//  column: UInt = #column
+//) {
+//  assertMacro(
+//    Dictionary(macros: macros),
+//    record: isRecording,
+//    of: originalSource,
+//    matches: expandedOrDiagnosedSource,
+//    file: file,
+//    function: function,
+//    line: line,
+//    column: column
+//  )
+//}
+//
+//@available(
+//  *, deprecated, message: "Delete 'applyFixIts' and 'matches' and re-record this assertion"
+//)
+//public func assertMacro(
+//  _ macros: [String: Macro.Type]? = nil,
+//  applyFixIts: Bool,
+//  record isRecording: Bool? = nil,
+//  of originalSource: () throws -> String,
+//  matches expandedOrDiagnosedSource: () -> String,
+//  file: StaticString = #filePath,
+//  function: StaticString = #function,
+//  line: UInt = #line,
+//  column: UInt = #column
+//) {
+//  XCTFail("Delete 'matches' and re-record this assertion", file: file, line: line)
+//}
+//
+//@available(
+//  *, deprecated, message: "Delete 'applyFixIts' and 'matches' and re-record this assertion"
+//)
+//public func assertMacro(
+//  _ macros: [Macro.Type],
+//  applyFixIts: Bool,
+//  record isRecording: Bool? = nil,
+//  of originalSource: () throws -> String,
+//  matches expandedOrDiagnosedSource: () -> String,
+//  file: StaticString = #filePath,
+//  function: StaticString = #function,
+//  line: UInt = #line,
+//  column: UInt = #column
+//) {
+//  assertMacro(
+//    Dictionary(macros: macros),
+//    applyFixIts: applyFixIts,
+//    record: isRecording,
+//    of: originalSource,
+//    matches: expandedOrDiagnosedSource,
+//    file: file,
+//    function: function,
+//    line: line,
+//    column: column
+//  )
+//}

--- a/Sources/MacroTesting/Internal/Diagnostic+UnderlineHighlights.swift
+++ b/Sources/MacroTesting/Internal/Diagnostic+UnderlineHighlights.swift
@@ -1,0 +1,44 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacroExpansion
+
+extension Array where Element == Diagnostic {
+  func underlineHighlights(
+    sourceString: String,
+    lineNumber: Int,
+    column: Int,
+    context: BasicMacroExpansionContext
+  ) -> String? {
+    let (highlightColumns, highlightLineLength) = self.reduce(
+      into: (highlightColumns: Set<Int>(), highlightLineLength: column + 1)
+    ) { partialResult, diag in
+      for highlight in diag.highlights {
+        let startLocation = context.location(
+          for: highlight.positionAfterSkippingLeadingTrivia, anchoredAt: diag.node, fileName: ""
+        )
+        let endLocation = context.location(
+          for: highlight.endPositionBeforeTrailingTrivia, anchoredAt: diag.node, fileName: ""
+        )
+        guard
+          startLocation.line == lineNumber,
+          startLocation.line == endLocation.line,
+          sourceString.contains(diag.node.trimmedDescription)
+        else { continue }
+        partialResult.highlightColumns.formUnion(startLocation.column..<endLocation.column)
+        partialResult.highlightLineLength = Swift.max(
+          partialResult.highlightLineLength, endLocation.column
+        )
+      }
+    }
+    guard !highlightColumns.isEmpty else { return nil }
+    return String(
+      (0..<highlightLineLength).map {
+        $0 == column
+          ? "┬"
+          : highlightColumns.contains($0)
+            ? "─"
+            : " "
+      }
+    )
+  }
+}

--- a/Sources/MacroTesting/SwiftDiagnostics/DiagnosticsFormatter.swift
+++ b/Sources/MacroTesting/SwiftDiagnostics/DiagnosticsFormatter.swift
@@ -1,0 +1,456 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacroExpansion
+
+extension Sequence where Element == Range<Int> {
+  /// Given a set of ranges that are sorted in order of nondecreasing lower
+  /// bound, merge any overlapping ranges to produce a sequence of
+  /// nonoverlapping ranges.
+  fileprivate func mergingOverlappingRanges() -> [Range<Int>] {
+    var result: [Range<Int>] = []
+
+    var prior: Range<Int>? = nil
+    for range in self {
+      // If this is the first range we've seen, note it as the prior and
+      // continue.
+      guard let priorRange = prior else {
+        prior = range
+        continue
+      }
+
+      // If the ranges overlap, expand the prior range.
+      precondition(priorRange.lowerBound <= range.lowerBound)
+      if priorRange.overlaps(range) {
+        let lower = priorRange.lowerBound
+        let upper = Swift.max(priorRange.upperBound, range.upperBound)
+        prior = lower..<upper
+        continue
+      }
+
+      // Append the prior range, then take this new range as the prior
+      result.append(priorRange)
+      prior = range
+    }
+
+    if let priorRange = prior {
+      result.append(priorRange)
+    }
+    return result
+  }
+}
+
+struct DiagnosticsFormatter {
+
+  /// A wrapper struct for a source line, its diagnostics, and any
+  /// non-diagnostic text that follows the line.
+  private struct AnnotatedSourceLine {
+    var diagnostics: [Diagnostic]
+    var sourceString: String
+
+    /// Non-diagnostic text that is appended after this source line.
+    ///
+    /// Suffix text can be used to provide more information following a source
+    /// line, such as to provide an inset source buffer for a macro expansion
+    /// that occurs on that line.
+    var suffixText: String
+
+    /// Whether this line is free of annotations.
+    var isFreeOfAnnotations: Bool {
+      return diagnostics.isEmpty && suffixText.isEmpty
+    }
+  }
+
+  /// Number of lines which should be printed before and after the diagnostic message
+  let contextSize: Int
+
+  /// Whether to colorize formatted diagnostics.
+  let colorize: Bool
+
+  init(contextSize: Int = 2, colorize: Bool = false) {
+    self.contextSize = contextSize
+    self.colorize = colorize
+  }
+
+  static func annotatedSource(
+    tree: some SyntaxProtocol,
+    diags: [Diagnostic],
+    context: BasicMacroExpansionContext,
+    contextSize: Int = 2,
+    colorize: Bool = false
+  ) -> String {
+    let formatter = DiagnosticsFormatter(contextSize: contextSize, colorize: colorize)
+    return formatter.annotatedSource(tree: tree, diags: diags, context: context)
+  }
+
+  /// Colorize the given source line by applying highlights from diagnostics.
+  private func colorizeSourceLine(
+    _ annotatedLine: AnnotatedSourceLine,
+    lineNumber: Int,
+    tree: some SyntaxProtocol,
+    sourceLocationConverter slc: SourceLocationConverter
+  ) -> String {
+    guard colorize, !annotatedLine.diagnostics.isEmpty else {
+      return annotatedLine.sourceString
+    }
+
+    // Compute the set of highlight ranges that land on this line. These
+    // are column ranges, sorted in order of increasing starting column, and
+    // with overlapping ranges merged.
+    let highlightRanges: [Range<Int>] = annotatedLine.diagnostics.map {
+      $0.highlights
+    }.joined().compactMap { (highlight) -> Range<Int>? in
+      if highlight.root != Syntax(tree) {
+        return nil
+      }
+
+      let startLoc = highlight.startLocation(converter: slc, afterLeadingTrivia: true)
+      let startLine = startLoc.line
+
+      // Find the starting column.
+      let startColumn: Int
+      if startLine < lineNumber {
+        startColumn = 1
+      } else if startLine == lineNumber {
+        startColumn = startLoc.column
+      } else {
+        return nil
+      }
+
+      // Find the ending column.
+      let endLoc = highlight.endLocation(converter: slc, afterTrailingTrivia: false)
+      let endLine = endLoc.line
+
+      let endColumn: Int
+      if endLine > lineNumber {
+        endColumn = annotatedLine.sourceString.count
+      } else if endLine == lineNumber {
+        endColumn = endLoc.column
+      } else {
+        return nil
+      }
+
+      if startColumn == endColumn {
+        return nil
+      }
+
+      return startColumn..<endColumn
+    }.sorted { (lhs, rhs) in
+      lhs.lowerBound < rhs.lowerBound
+    }.mergingOverlappingRanges()
+
+    // Map the column ranges into index ranges within the source string itself.
+    let sourceStringUTF8 = annotatedLine.sourceString.utf8
+    let highlightIndexRanges: [Range<String.Index>] = highlightRanges.map { highlightRange in
+      let startIndex = sourceStringUTF8.index(
+        sourceStringUTF8.startIndex, offsetBy: highlightRange.lowerBound - 1)
+      let endIndex = sourceStringUTF8.index(startIndex, offsetBy: highlightRange.count)
+      return startIndex..<endIndex
+    }
+
+    // Form the annotated string by copying in text from the original source,
+    // highlighting the column ranges.
+    var resultSourceString: String = ""
+    let annotation = ANSIAnnotation.sourceHighlight
+    let sourceString = annotatedLine.sourceString
+    var sourceIndex = sourceString.startIndex
+    for highlightRange in highlightIndexRanges {
+      // Text before the highlight range
+      resultSourceString += sourceString[sourceIndex..<highlightRange.lowerBound]
+
+      // Highlighted source text
+      let highlightString = String(sourceString[highlightRange])
+      resultSourceString += annotation.applied(to: highlightString)
+
+      sourceIndex = highlightRange.upperBound
+    }
+
+    resultSourceString += sourceString[sourceIndex...]
+    return resultSourceString
+  }
+
+  /// Print given diagnostics for a given syntax tree on the command line
+  ///
+  /// - Parameters:
+  ///   - suffixTexts: suffix text to be printed at the given absolute
+  ///                  locations within the source file.
+  func annotatedSource(
+    fileName: String?,
+    tree: some SyntaxProtocol,
+    diags: [Diagnostic],
+    context: BasicMacroExpansionContext,
+    indentString: String,
+    suffixTexts: [AbsolutePosition: String],
+    sourceLocationConverter: SourceLocationConverter? = nil
+  ) -> String {
+    let slc =
+      sourceLocationConverter ?? SourceLocationConverter(fileName: fileName ?? "", tree: tree)
+
+    // First, we need to put each line and its diagnostics together
+    var annotatedSourceLines = [AnnotatedSourceLine]()
+
+    for (sourceLineIndex, sourceLine) in slc.sourceLines.enumerated() {
+      let diagsForLine = diags.filter { diag in
+        return diag.location(converter: slc).line == (sourceLineIndex + 1)
+      }
+      let suffixText = suffixTexts.compactMap { (position, text) in
+        if slc.location(for: position).line == (sourceLineIndex + 1) {
+          return text
+        }
+
+        return nil
+      }.joined()
+
+      annotatedSourceLines.append(
+        AnnotatedSourceLine(
+          diagnostics: diagsForLine, sourceString: sourceLine, suffixText: suffixText))
+    }
+
+    // Only lines with diagnostic messages should be printed, but including some context
+    let rangesToPrint = annotatedSourceLines.enumerated().compactMap {
+      (lineIndex, sourceLine) -> Range<Int>? in
+      let lineNumber = lineIndex + 1
+      if !sourceLine.isFreeOfAnnotations {
+        return Range<Int>(
+          uncheckedBounds: (lower: lineNumber - contextSize, upper: lineNumber + contextSize + 1))
+      }
+      return nil
+    }
+
+    var annotatedSource = ""
+
+    // If there was a filename, add it first.
+    if let fileName {
+      let header = colorizeBufferOutline("===")
+      let firstLine =
+        1
+        + (annotatedSourceLines.enumerated().first { (lineIndex, sourceLine) in
+          !sourceLine.isFreeOfAnnotations
+        }?.offset ?? 0)
+
+      annotatedSource.append("\(indentString)\(header) \(fileName):\(firstLine) \(header)\n")
+    }
+
+    /// Keep track if a line missing char should be printed
+    var hasLineBeenSkipped = false
+
+    let maxNumberOfDigits = String(annotatedSourceLines.count).count
+
+    for (lineIndex, annotatedLine) in annotatedSourceLines.enumerated() {
+      let lineNumber = lineIndex + 1
+      guard
+        rangesToPrint.contains(where: { range in
+          range.contains(lineNumber)
+        })
+      else {
+        hasLineBeenSkipped = true
+        continue
+      }
+
+      // line numbers should be right aligned
+      let lineNumberString = String(lineNumber)
+      let leadingSpaces = String(repeating: " ", count: maxNumberOfDigits - lineNumberString.count)
+      let linePrefix = "\(leadingSpaces)\(colorizeBufferOutline("\(lineNumberString) │")) "
+
+      // If necessary, print a line that indicates that there was lines skipped in the source code
+      if hasLineBeenSkipped && !annotatedSource.isEmpty {
+        let lineMissingInfoLine =
+          indentString + String(repeating: " ", count: maxNumberOfDigits)
+          + " \(colorizeBufferOutline("┆"))"
+        annotatedSource.append("\(lineMissingInfoLine)\n")
+      }
+      hasLineBeenSkipped = false
+
+      // add indentation
+      annotatedSource.append(indentString)
+
+      // print the source line
+      annotatedSource.append(linePrefix)
+      annotatedSource.append(
+        colorizeSourceLine(
+          annotatedLine,
+          lineNumber: lineNumber,
+          tree: tree,
+          sourceLocationConverter: slc
+        )
+      )
+
+      // If the line did not end with \n (e.g. the last line), append it manually
+      if annotatedSource.last != "\n" {
+        annotatedSource.append("\n")
+      }
+
+      let columnsWithDiagnostics = Set(
+        annotatedLine.diagnostics.map { $0.location(converter: slc).column })
+      let diagsPerColumn = Dictionary(grouping: annotatedLine.diagnostics) { diag in
+        diag.location(converter: slc).column
+      }.sorted { lhs, rhs in
+        lhs.key > rhs.key
+      }
+
+      let preMessagePrefix =
+        indentString + String(repeating: " ", count: maxNumberOfDigits) + " "
+        + colorizeBufferOutline("│")
+      for (column, diags) in diagsPerColumn {
+        // compute the string that is shown before each message
+        var preMessage = preMessagePrefix
+        for c in 0..<column {
+          if columnsWithDiagnostics.contains(c) {
+            preMessage.append("│")
+          } else {
+            preMessage.append(" ")
+          }
+        }
+
+        if let underlines = diags.underlineHighlights(
+          sourceString: annotatedLine.sourceString,
+          lineNumber: lineNumber,
+          column: column,
+          context: context
+        ) {
+          annotatedSource.append("\(preMessagePrefix)\(underlines)\n")
+        }
+        for diag in diags.dropLast(1) {
+          annotatedSource.append("\(preMessage)├─ \(colorizeIfRequested(diag.diagMessage))\n")
+          for fixIt in diag.fixIts {
+            annotatedSource.append("\(preMessage)│  ✏️ \(fixIt.message.message)\n")
+          }
+        }
+        annotatedSource.append("\(preMessage)╰─ \(colorizeIfRequested(diags.last!.diagMessage))\n")
+        for fixIt in diags.last!.fixIts {
+          annotatedSource.append("\(preMessage)   ✏️ \(fixIt.message.message)\n")
+        }
+      }
+
+      // Add suffix text.
+      annotatedSource.append(annotatedLine.suffixText)
+      if annotatedSource.last != "\n" {
+        annotatedSource.append("\n")
+      }
+    }
+    return annotatedSource
+  }
+
+  /// Print given diagnostics for a given syntax tree on the command line
+  func annotatedSource(
+    tree: some SyntaxProtocol,
+    diags: [Diagnostic],
+    context: BasicMacroExpansionContext
+  ) -> String {
+    return annotatedSource(
+      fileName: nil,
+      tree: tree,
+      diags: diags,
+      context: context,
+      indentString: "",
+      suffixTexts: [:]
+    )
+  }
+
+  /// Annotates the given ``DiagnosticMessage`` with an appropriate ANSI color code (if the value of the `colorize`
+  /// property is `true`) and returns the result as a printable string.
+  private func colorizeIfRequested(_ message: DiagnosticMessage) -> String {
+    switch message.severity {
+    case .error:
+      let annotation = ANSIAnnotation(color: .red, trait: .bold)
+      return colorizeIfRequested("🛑 \(message.message)", annotation: annotation)
+
+    case .warning:
+      let color = ANSIAnnotation(color: .yellow)
+      let prefix = colorizeIfRequested("⚠️ ", annotation: color.withTrait(.bold))
+
+      return prefix + colorizeIfRequested(message.message, annotation: color)
+    default:
+      let color = ANSIAnnotation(color: .default, trait: .bold)
+      let prefix = colorizeIfRequested("ℹ️ ", annotation: color)
+      return prefix + message.message
+    }
+  }
+
+  /// Apply the given color and trait to the specified text, when we are
+  /// supposed to color the output.
+  private func colorizeIfRequested(
+    _ text: String,
+    annotation: ANSIAnnotation
+  ) -> String {
+    guard colorize, !text.isEmpty else {
+      return text
+    }
+
+    return annotation.applied(to: text)
+  }
+
+  /// Colorize for the buffer outline and line numbers.
+  func colorizeBufferOutline(_ text: String) -> String {
+    colorizeIfRequested(text, annotation: .bufferOutline)
+  }
+}
+
+struct ANSIAnnotation {
+  enum Color: UInt8 {
+    case normal = 0
+    case black = 30
+    case red = 31
+    case green = 32
+    case yellow = 33
+    case blue = 34
+    case magenta = 35
+    case cyan = 36
+    case white = 37
+    case `default` = 39
+  }
+
+  enum Trait: UInt8 {
+    case normal = 0
+    case bold = 1
+    case underline = 4
+  }
+
+  var color: Color
+  var trait: Trait
+
+  /// The textual representation of the annotation.
+  var code: String {
+    "\u{001B}[\(trait.rawValue);\(color.rawValue)m"
+  }
+
+  init(color: Color, trait: Trait = .normal) {
+    self.color = color
+    self.trait = trait
+  }
+
+  func withTrait(_ trait: Trait) -> Self {
+    return ANSIAnnotation(color: self.color, trait: trait)
+  }
+
+  func applied(to message: String) -> String {
+    // Resetting after the message ensures that we don't color unintended lines in the output
+    return "\(code)\(message)\(ANSIAnnotation.normal.code)"
+  }
+
+  /// The "normal" or "reset" ANSI code used to unset any previously added annotation.
+  static var normal: ANSIAnnotation {
+    self.init(color: .normal, trait: .normal)
+  }
+
+  /// Annotation used for the outline and line numbers of a buffer.
+  static var bufferOutline: ANSIAnnotation {
+    ANSIAnnotation(color: .cyan, trait: .normal)
+  }
+
+  /// Annotation used for highlighting source text.
+  static var sourceHighlight: ANSIAnnotation {
+    ANSIAnnotation(color: .default, trait: .underline)
+  }
+}

--- a/Sources/MacroTesting/SwiftSyntax/SourceEdit.swift
+++ b/Sources/MacroTesting/SwiftSyntax/SourceEdit.swift
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+/// A textual edit to the original source represented by a range and a
+/// replacement.
+public struct SourceEdit: Equatable {
+  /// The half-open range that this edit applies to.
+  public let range: Range<AbsolutePosition>
+  /// The text to replace the original range with. Empty for a deletion.
+  public let replacement: String
+
+  /// Length of the original source range that this edit applies to. Zero if
+  /// this is an addition.
+  public var length: SourceLength {
+    return SourceLength(utf8Length: range.lowerBound.utf8Offset - range.upperBound.utf8Offset)
+  }
+
+  /// Create an edit to replace `range` in the original source with
+  /// `replacement`.
+  public init(range: Range<AbsolutePosition>, replacement: String) {
+    self.range = range
+    self.replacement = replacement
+  }
+
+  /// Convenience function to create a textual addition after the given node
+  /// and its trivia.
+  public static func insert(_ newText: String, after node: some SyntaxProtocol) -> SourceEdit {
+    return SourceEdit(range: node.endPosition..<node.endPosition, replacement: newText)
+  }
+
+  /// Convenience function to create a textual addition before the given node
+  /// and its trivia.
+  public static func insert(_ newText: String, before node: some SyntaxProtocol) -> SourceEdit {
+    return SourceEdit(range: node.position..<node.position, replacement: newText)
+  }
+
+  /// Convenience function to create a textual replacement of the given node,
+  /// including its trivia.
+  public static func replace(_ node: some SyntaxProtocol, with replacement: String) -> SourceEdit {
+    return SourceEdit(range: node.position..<node.endPosition, replacement: replacement)
+  }
+
+  /// Convenience function to create a textual deletion the given node and its
+  /// trivia.
+  public static func remove(_ node: some SyntaxProtocol) -> SourceEdit {
+    return SourceEdit(range: node.position..<node.endPosition, replacement: "")
+  }
+}
+
+extension SourceEdit: CustomDebugStringConvertible {
+  public var debugDescription: String {
+    let hasNewline = replacement.contains { $0.isNewline }
+    if hasNewline {
+      return #"""
+        \#(range.lowerBound.utf8Offset)-\#(range.upperBound.utf8Offset)
+        """
+        \#(replacement)
+        """
+        """#
+    }
+    return "\(range.lowerBound.utf8Offset)-\(range.upperBound.utf8Offset) \"\(replacement)\""
+  }
+}

--- a/Sources/MacroTesting/_SwiftSyntaxTestSupport/FixItApplier.swift
+++ b/Sources/MacroTesting/_SwiftSyntaxTestSupport/FixItApplier.swift
@@ -1,0 +1,109 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacroExpansion
+
+public enum FixItApplier {
+  /// Applies selected or all Fix-Its from the provided diagnostics to a given syntax tree.
+  ///
+  /// - Parameters:
+  ///   - diagnostics: An array of `Diagnostic` objects, each containing one or more Fix-Its.
+  ///   - filterByMessages: An optional array of message strings to filter which Fix-Its to apply.
+  ///     If `nil`, the first Fix-It from each diagnostic is applied.
+  ///   - tree: The syntax tree to which the Fix-Its will be applied.
+  ///
+  /// - Returns: A `String` representation of the modified syntax tree after applying the Fix-Its.
+  //  public static func applyFixes(
+  //    from diagnostics: [Diagnostic],
+  //    filterByMessages messages: [String]?,
+  //    to tree: any SyntaxProtocol
+  //  ) -> String {
+  //    let messages = messages ?? diagnostics.compactMap { $0.fixIts.first?.message.message }
+  //
+  //    let edits =
+  //      diagnostics
+  //      .flatMap(\.fixIts)
+  //      .filter { messages.contains($0.message.message) }
+  //      .flatMap(\.edits)
+  //
+  //    return self.apply(edits: edits, to: tree)
+  //  }
+
+  /// Apply the given edits to the syntax tree.
+  ///
+  /// - Parameters:
+  ///   - edits: The edits to apply to the syntax tree
+  ///   - tree: he syntax tree to which the edits should be applied.
+  /// - Returns: A `String` representation of the modified syntax tree after applying the edits.
+  public static func apply(
+    edits: [SourceEdit],
+    to tree: any SyntaxProtocol
+  ) -> String {
+    var edits = edits
+    var source = tree.description
+
+    while let edit = edits.first {
+      edits = Array(edits.dropFirst())
+
+      let startIndex = source.utf8.index(source.utf8.startIndex, offsetBy: edit.startUtf8Offset)
+      let endIndex = source.utf8.index(source.utf8.startIndex, offsetBy: edit.endUtf8Offset)
+
+      source.replaceSubrange(startIndex..<endIndex, with: edit.replacement)
+
+      edits = edits.compactMap { remainingEdit -> SourceEdit? in
+        if remainingEdit.replacementRange.overlaps(edit.replacementRange) {
+          // The edit overlaps with the previous edit. We can't apply both
+          // without conflicts. Apply the one that's listed first and drop the
+          // later edit.
+          return nil
+        }
+
+        // If the remaining edit starts after or at the end of the edit that we just applied,
+        // shift it by the current edit's difference in length.
+        if edit.endUtf8Offset <= remainingEdit.startUtf8Offset {
+          let startPosition = AbsolutePosition(
+            utf8Offset: remainingEdit.startUtf8Offset - edit.replacementRange.count
+              + edit.replacementLength)
+          let endPosition = AbsolutePosition(
+            utf8Offset: remainingEdit.endUtf8Offset - edit.replacementRange.count
+              + edit.replacementLength)
+          return SourceEdit(
+            range: startPosition..<endPosition, replacement: remainingEdit.replacement)
+        }
+
+        return remainingEdit
+      }
+    }
+
+    return source
+  }
+}
+
+extension SourceEdit {
+  fileprivate var startUtf8Offset: Int {
+    return range.lowerBound.utf8Offset
+  }
+
+  fileprivate var endUtf8Offset: Int {
+    return range.upperBound.utf8Offset
+  }
+
+  fileprivate var replacementLength: Int {
+    return replacement.utf8.count
+  }
+
+  fileprivate var replacementRange: Range<Int> {
+    return startUtf8Offset..<endUtf8Offset
+  }
+}

--- a/Sources/MemberwiseInitMacros/Macros/MemberwiseInitMacro.swift
+++ b/Sources/MemberwiseInitMacros/Macros/MemberwiseInitMacro.swift
@@ -89,22 +89,22 @@ public struct MemberwiseInitMacro: MemberMacro {
     ]
   }
 
-  private static func extractConfiguredAccessLevel(
+  static func extractConfiguredAccessLevel(
     from node: AttributeSyntax
   ) -> AccessLevelModifier? {
     guard let arguments = node.arguments?.as(LabeledExprListSyntax.self)
     else { return nil }
 
-    // NB: Search for the first argument who's name matches an access level name
-    return arguments.compactMap { labeledExprSyntax -> AccessLevelModifier? in
-      guard
-        let identifier = labeledExprSyntax.expression.as(MemberAccessExprSyntax.self)?.declName,
+    // NB: Search for the first argument whose name matches an access level name
+    for labeledExprSyntax in arguments {
+      if let identifier = labeledExprSyntax.expression.as(MemberAccessExprSyntax.self)?.declName,
         let accessLevel = AccessLevelModifier(rawValue: identifier.baseName.trimmedDescription)
-      else { return nil }
-
-      return accessLevel
+      {
+        return accessLevel
+      }
     }
-    .first
+
+    return nil
   }
 
   private static func extractLabeledBoolArgument(

--- a/Tests/MacroTestingTests/AddAsyncTests.swift
+++ b/Tests/MacroTestingTests/AddAsyncTests.swift
@@ -1,0 +1,109 @@
+import MacroTesting
+import XCTest
+
+final class AddAsyncMacroTests: BaseTestCase {
+  override func invokeTest() {
+    withMacroTesting(macros: [AddAsyncMacro.self]) {
+      super.invokeTest()
+    }
+  }
+
+  func testExpansionTransformsFunctionWithResultCompletionToAsyncThrows() {
+    assertMacro {
+      #"""
+      @AddAsync
+      func c(a: Int, for b: String, _ value: Double, completionBlock: @escaping (Result<String, Error>) -> Void) -> Void {
+        completionBlock(.success("a: \(a), b: \(b), value: \(value)"))
+      }
+      """#
+    } expansion: {
+      #"""
+      func c(a: Int, for b: String, _ value: Double, completionBlock: @escaping (Result<String, Error>) -> Void) -> Void {
+        completionBlock(.success("a: \(a), b: \(b), value: \(value)"))
+      }
+
+      func c(a: Int, for b: String, _ value: Double) async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+          c(a: a, for: b, value) { returnValue in
+
+            switch returnValue {
+            case .success(let value):
+              continuation.resume(returning: value)
+            case .failure(let error):
+              continuation.resume(throwing: error)
+            }
+          }
+        }
+      }
+      """#
+    }
+  }
+
+  func testExpansionTransformsFunctionWithBoolCompletionToAsync() {
+    assertMacro {
+      """
+      @AddAsync
+      func d(a: Int, for b: String, _ value: Double, completionBlock: @escaping (Bool) -> Void) -> Void {
+        completionBlock(true)
+      }
+      """
+    } expansion: {
+      """
+      func d(a: Int, for b: String, _ value: Double, completionBlock: @escaping (Bool) -> Void) -> Void {
+        completionBlock(true)
+      }
+
+      func d(a: Int, for b: String, _ value: Double) async -> Bool {
+        await withCheckedContinuation { continuation in
+          d(a: a, for: b, value) { returnValue in
+
+            continuation.resume(returning: returnValue)
+          }
+        }
+      }
+      """
+    }
+  }
+
+  func testExpansionOnStoredPropertyEmitsError() {
+    assertMacro {
+      """
+      struct Test {
+        @AddAsync
+        var name: String
+      }
+      """
+    } diagnostics: {
+      """
+      struct Test {
+        @AddAsync
+        ┬────────
+        ╰─ 🛑 @addAsync only works on functions
+        var name: String
+      }
+      """
+    }
+  }
+
+  func testExpansionOnAsyncFunctionEmitsError() {
+    assertMacro {
+      """
+      struct Test {
+        @AddAsync
+        async func sayHello() {
+        }
+      }
+      """
+    } diagnostics: {
+      """
+      struct Test {
+        @AddAsync
+        ┬────────
+        ╰─ 🛑 @addAsync requires an function that returns void
+        async func sayHello() {
+        }
+      }
+      """
+    }
+  }
+}

--- a/Tests/MacroTestingTests/AddBlockerTests.swift
+++ b/Tests/MacroTestingTests/AddBlockerTests.swift
@@ -1,0 +1,50 @@
+import MacroTesting
+import XCTest
+
+final class AddBlockerTests: BaseTestCase {
+  override func invokeTest() {
+    withMacroTesting(macros: [AddBlocker.self]) {
+      super.invokeTest()
+    }
+  }
+
+  func testExpansionTransformsAdditionToSubtractionAndEmitsWarning() {
+    assertMacro {
+      """
+      #addBlocker(x * y + z)
+      """
+    } expansion: {
+      """
+      x * y - z
+      """
+    } diagnostics: {
+      """
+      #addBlocker(x * y + z)
+                  ───── ┬ ─
+                        ╰─ ⚠️ blocked an add; did you mean to subtract?
+                           ✏️ use '-'
+      """
+    } fixes: {
+      """
+      #addBlocker(x * y + z)
+                  ───── ┬ ─
+                        ╰─ ⚠️ blocked an add; did you mean to subtract?
+
+      ✏️ use '-'
+      #addBlocker(x * y - z)
+      """
+    }
+  }
+
+  func testExpansionPreservesSubtraction() {
+    assertMacro {
+      """
+      #addBlocker(x * y - z)
+      """
+    } expansion: {
+      """
+      x * y - z
+      """
+    }
+  }
+}

--- a/Tests/MacroTestingTests/AddCompletionHandlerTests.swift
+++ b/Tests/MacroTestingTests/AddCompletionHandlerTests.swift
@@ -1,0 +1,92 @@
+import MacroTesting
+import XCTest
+
+final class AddCompletionHandlerTests: BaseTestCase {
+  override func invokeTest() {
+    withMacroTesting(macros: [AddCompletionHandlerMacro.self]) {
+      super.invokeTest()
+    }
+  }
+
+  func testExpansionTransformsAsyncFunctionToCompletion() {
+    assertMacro {
+      """
+      @AddCompletionHandler
+      func f(a: Int, for b: String, _ value: Double) async -> String {
+        return b
+      }
+      """
+    } expansion: {
+      """
+      func f(a: Int, for b: String, _ value: Double) async -> String {
+        return b
+      }
+
+      func f(a: Int, for b: String, _ value: Double, completionHandler: @escaping (String) -> Void) {
+        Task {
+          completionHandler(await f(a: a, for: b, value))
+        }
+      }
+      """
+    }
+  }
+
+  func testExpansionOnStoredPropertyEmitsError() {
+    assertMacro {
+      """
+      struct Test {
+        @AddCompletionHandler
+        var value: Int
+      }
+      """
+    } diagnostics: {
+      """
+      struct Test {
+        @AddCompletionHandler
+        ┬────────────────────
+        ╰─ 🛑 @addCompletionHandler only works on functions
+        var value: Int
+      }
+      """
+    }
+  }
+
+  func testExpansionOnNonAsyncFunctionEmitsErrorWithFixItSuggestion() {
+    assertMacro {
+      """
+      struct Test {
+        @AddCompletionHandler
+        func fetchData() -> String {
+          return "Hello, World!"
+        }
+      }
+      """
+    } diagnostics: {
+      """
+      struct Test {
+        @AddCompletionHandler
+        func fetchData() -> String {
+        ┬───
+        ╰─ 🛑 can only add a completion-handler variant to an 'async' function
+           ✏️ add 'async'
+          return "Hello, World!"
+        }
+      }
+      """
+    } fixes: {
+      """
+      func fetchData() -> String {
+      ┬───
+      ╰─ 🛑 can only add a completion-handler variant to an 'async' function
+
+      ✏️ add 'async'
+      struct Test {
+        @AddCompletionHandler
+        func fetchData() async-> String {
+          return "Hello, World!"
+        }
+      }
+      """
+    }
+  }
+}

--- a/Tests/MacroTestingTests/AssertMacroTests.swift
+++ b/Tests/MacroTestingTests/AssertMacroTests.swift
@@ -1,0 +1,33 @@
+import MacroTesting
+import XCTest
+
+final class AssertMacroTests: BaseTestCase {
+  #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS) || os(watchOS)
+    func testMacrosRequired() {
+      XCTExpectFailure {
+        assertMacro {
+          """
+          #forgotToConfigure()
+          """
+        }
+      } issueMatcher: {
+        $0.compactDescription == """
+          failed - No macros configured for this assertion. Pass a mapping to this function, e.g.:
+
+              assertMacro(["stringify": StringifyMacro.self]) { … }
+
+          Or wrap your assertion using 'withMacroTesting', e.g. in 'invokeTest':
+
+              class StringifyMacroTests: XCTestCase {
+                override func invokeTest() {
+                  withMacroTesting(macros: ["stringify": StringifyMacro.self]) {
+                    super.invokeTest()
+                  }
+                }
+                …
+              }
+          """
+      }
+    }
+  #endif
+}

--- a/Tests/MacroTestingTests/BaseTestCase.swift
+++ b/Tests/MacroTestingTests/BaseTestCase.swift
@@ -1,0 +1,10 @@
+import MacroTesting
+import XCTest
+
+class BaseTestCase: XCTestCase {
+  // override func invokeTest() {
+  //   withMacroTesting(isRecording: true) {
+  //     super.invokeTest()
+  //   }
+  // }
+}

--- a/Tests/MacroTestingTests/CaseDetectionMacroTests.swift
+++ b/Tests/MacroTestingTests/CaseDetectionMacroTests.swift
@@ -1,0 +1,45 @@
+import MacroTesting
+import XCTest
+
+final class CaseDetectionMacroTests: BaseTestCase {
+  override func invokeTest() {
+    withMacroTesting(macros: [CaseDetectionMacro.self]) {
+      super.invokeTest()
+    }
+  }
+
+  func testExpansionAddsComputedProperties() {
+    assertMacro {
+      """
+      @CaseDetection
+      enum Animal {
+        case dog
+        case cat(curious: Bool)
+      }
+      """
+    } expansion: {
+      """
+      enum Animal {
+        case dog
+        case cat(curious: Bool)
+
+        var isDog: Bool {
+          if case .dog = self {
+            return true
+          }
+
+          return false
+        }
+
+        var isCat: Bool {
+          if case .cat = self {
+            return true
+          }
+
+          return false
+        }
+      }
+      """
+    }
+  }
+}

--- a/Tests/MacroTestingTests/CustomCodableMacroTests.swift
+++ b/Tests/MacroTestingTests/CustomCodableMacroTests.swift
@@ -1,0 +1,62 @@
+import MacroTesting
+import XCTest
+
+final class CustomCodableMacroTests: BaseTestCase {
+  override func invokeTest() {
+    withMacroTesting(macros: [CodableKey.self, CustomCodable.self]) {
+      super.invokeTest()
+    }
+  }
+
+  func testExpansionAddsDefaultCodingKeys() {
+    assertMacro {
+      """
+      @CustomCodable
+      struct Person {
+        let name: String
+        let age: Int
+      }
+      """
+    } expansion: {
+      """
+      struct Person {
+        let name: String
+        let age: Int
+
+        enum CodingKeys: String, CodingKey {
+          case name
+          case age
+        }
+      }
+      """
+    }
+  }
+
+  func testExpansionWithCodableKeyAddsCustomCodingKeys() {
+    assertMacro {
+      """
+      @CustomCodable
+      struct Person {
+        let name: String
+        @CodableKey("user_age") let age: Int
+
+        func randomFunction() {}
+      }
+      """
+    } expansion: {
+      """
+      struct Person {
+        let name: String
+        let age: Int
+
+        func randomFunction() {}
+
+        enum CodingKeys: String, CodingKey {
+          case name
+          case age = "user_age"
+        }
+      }
+      """
+    }
+  }
+}

--- a/Tests/MacroTestingTests/DiagnosticsAndFixitsEmitterMacroTests.swift
+++ b/Tests/MacroTestingTests/DiagnosticsAndFixitsEmitterMacroTests.swift
@@ -1,0 +1,55 @@
+import MacroTesting
+import XCTest
+
+final class DiagnosticsAndFixitsEmitterMacroTests: BaseTestCase {
+  override func invokeTest() {
+    withMacroTesting(macros: [DiagnosticsAndFixitsEmitterMacro.self]) {
+      super.invokeTest()
+    }
+  }
+
+  func testExpansionEmitsDiagnosticsAndFixits() {
+    assertMacro {
+      """
+      @DiagnosticsAndFixitsEmitter
+      struct FooBar {
+        let foo: Foo
+        let bar: Bar
+      }
+      """
+    } diagnostics: {
+      """
+      @DiagnosticsAndFixitsEmitter
+       ┬──────────────────────────
+       ├─ ⚠️ This is the first diagnostic.
+       │  ✏️ This is the first fix-it.
+       │  ✏️ This is the second fix-it.
+       ╰─ ℹ️ This is the second diagnostic, it's a note.
+      struct FooBar {
+        let foo: Foo
+        let bar: Bar
+      }
+      """
+    } fixes: {
+      """
+      @DiagnosticsAndFixitsEmitter
+       ┬──────────────────────────
+       ╰─ ⚠️ This is the first diagnostic.
+
+      ✏️ This is the first fix-it.
+      @DiagnosticsAndFixitsEmitter
+      struct FooBar {
+        let foo: Foo
+        let bar: Bar
+      }
+
+      ✏️ This is the second fix-it.
+      @DiagnosticsAndFixitsEmitter
+      struct FooBar {
+        let foo: Foo
+        let bar: Bar
+      }
+      """
+    }
+  }
+}

--- a/Tests/MacroTestingTests/DictionaryStorageMacroTests.swift
+++ b/Tests/MacroTestingTests/DictionaryStorageMacroTests.swift
@@ -1,0 +1,106 @@
+import MacroTesting
+import XCTest
+
+final class DictionaryStorageMacroTests: BaseTestCase {
+  override func invokeTest() {
+    withMacroTesting(
+      macros: [
+        DictionaryStorageMacro.self,
+        DictionaryStoragePropertyMacro.self,
+      ]
+    ) {
+      super.invokeTest()
+    }
+  }
+
+  func testExpansionConvertsStoredProperties() {
+    assertMacro {
+      """
+      @DictionaryStorage
+      struct Point {
+        var x: Int = 1
+        var y: Int = 2
+      }
+      """
+    } expansion: {
+      """
+      struct Point {
+        var x: Int = 1 {
+          get {
+            _storage["x", default: 1] as! Int
+          }
+          set {
+            _storage["x"] = newValue
+          }
+        }
+        var y: Int = 2 {
+          get {
+            _storage["y", default: 2] as! Int
+          }
+          set {
+            _storage["y"] = newValue
+          }
+        }
+
+        var _storage: [String: Any] = [:]
+      }
+      """
+    }
+  }
+
+  func testExpansionWithoutInitializersEmitsError() {
+    assertMacro {
+      """
+      @DictionaryStorage
+      class Point {
+        let x: Int
+        let y: Int
+      }
+      """
+    } expansion: {
+      """
+      class Point {
+        let x: Int
+        let y: Int
+
+        var _storage: [String: Any] = [:]
+      }
+      """
+    } diagnostics: {
+      """
+      @DictionaryStorage
+      class Point {
+        let x: Int
+        ╰─ 🛑 stored property must have an initializer
+        let y: Int
+        ╰─ 🛑 stored property must have an initializer
+      }
+      """
+    }
+  }
+
+  func testExpansionIgnoresComputedProperties() {
+    assertMacro {
+      """
+      @DictionaryStorage
+      struct Test {
+        var value: Int {
+          get { return 0 }
+          set {}
+        }
+      }
+      """
+    } expansion: {
+      """
+      struct Test {
+        var value: Int {
+          get { return 0 }
+          set {}
+        }
+
+        var _storage: [String: Any] = [:]
+      }
+      """
+    }
+  }
+}

--- a/Tests/MacroTestingTests/EquatableExtensionMacroTests.swift
+++ b/Tests/MacroTestingTests/EquatableExtensionMacroTests.swift
@@ -1,0 +1,32 @@
+import MacroTesting
+import XCTest
+
+final class EquatableExtensionMacroTests: XCTestCase {
+  override func invokeTest() {
+    withMacroTesting(macros: ["equatable": EquatableExtensionMacro.self]) {
+      super.invokeTest()
+    }
+  }
+
+  func testExpansionAddsExtensionWithEquatableConformance() {
+    assertMacro {
+      """
+      @equatable
+      final public class Message {
+        let text: String
+        let sender: String
+      }
+      """
+    } expansion: {
+      """
+      final public class Message {
+        let text: String
+        let sender: String
+      }
+
+      extension Message: Equatable {
+      }
+      """
+    }
+  }
+}

--- a/Tests/MacroTestingTests/FixItTests.swift
+++ b/Tests/MacroTestingTests/FixItTests.swift
@@ -1,0 +1,93 @@
+import MacroTesting
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import XCTest
+
+private enum ReplaceFirstMemberMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard
+      let nodeToReplace = declaration.memberBlock.members.first,
+      let newNode = try? MemberBlockItemSyntax(
+        decl: VariableDeclSyntax(SyntaxNodeString(stringLiteral: "\n  let oye: Oye"))
+      )
+    else { return [] }
+
+    context.diagnose(
+      Diagnostic(
+        node: node.attributeName,
+        message: SimpleDiagnosticMessage(
+          message: "First member needs to be replaced",
+          diagnosticID: MessageID(domain: "domain", id: "diagnostic2"),
+          severity: .warning
+        ),
+        fixIts: [
+          FixIt(
+            message: SimpleDiagnosticMessage(
+              message: "Replace the first member",
+              diagnosticID: MessageID(domain: "domain", id: "fixit1"),
+              severity: .error
+            ),
+            changes: [
+              .replace(oldNode: Syntax(nodeToReplace), newNode: Syntax(newNode))
+            ]
+          )
+        ]
+      )
+    )
+
+    return []
+  }
+}
+
+final class FixItTests: BaseTestCase {
+  override func invokeTest() {
+    withMacroTesting(macros: [ReplaceFirstMemberMacro.self]) {
+      super.invokeTest()
+    }
+  }
+
+  func testReplaceFirstMember() {
+    assertMacro {
+      """
+      @ReplaceFirstMember
+      struct FooBar {
+        let foo: Foo
+        let bar: Bar
+        let baz: Baz
+      }
+      """
+    } diagnostics: {
+      """
+      @ReplaceFirstMember
+       ┬─────────────────
+       ╰─ ⚠️ First member needs to be replaced
+          ✏️ Replace the first member
+      struct FooBar {
+        let foo: Foo
+        let bar: Bar
+        let baz: Baz
+      }
+      """
+    } fixes: {
+      """
+      @ReplaceFirstMember
+       ┬─────────────────
+       ╰─ ⚠️ First member needs to be replaced
+
+      ✏️ Replace the first member
+      @ReplaceFirstMember
+      struct FooBar {
+        let oye: Oye
+        let bar: Bar
+        let baz: Baz
+      }
+      """
+    }
+  }
+}

--- a/Tests/MacroTestingTests/FontLiteralMacroTests.swift
+++ b/Tests/MacroTestingTests/FontLiteralMacroTests.swift
@@ -1,0 +1,34 @@
+import MacroTesting
+import XCTest
+
+final class FontLiteralMacroTests: BaseTestCase {
+  override func invokeTest() {
+    withMacroTesting(macros: [FontLiteralMacro.self]) {
+      super.invokeTest()
+    }
+  }
+
+  func testExpansionWithNamedArguments() {
+    assertMacro {
+      """
+      #fontLiteral(name: "Comic Sans", size: 14, weight: .thin)
+      """
+    } expansion: {
+      """
+      .init(fontLiteralName: "Comic Sans", size: 14, weight: .thin)
+      """
+    }
+  }
+
+  func testExpansionWithUnlabeledFirstArgument() {
+    assertMacro {
+      """
+      #fontLiteral("Copperplate Gothic", size: 69, weight: .bold)
+      """
+    } expansion: {
+      """
+      .init(fontLiteralName: "Copperplate Gothic", size: 69, weight: .bold)
+      """
+    }
+  }
+}

--- a/Tests/MacroTestingTests/FuncUniqueMacroTests.swift
+++ b/Tests/MacroTestingTests/FuncUniqueMacroTests.swift
@@ -1,0 +1,27 @@
+import MacroTesting
+import XCTest
+
+final class FuncUniqueMacroTests: BaseTestCase {
+  override func invokeTest() {
+    withMacroTesting(
+      macros: [FuncUniqueMacro.self]
+    ) {
+      super.invokeTest()
+    }
+  }
+
+  func testExpansionCreatesDeclarationWithUniqueFunction() {
+    assertMacro {
+      """
+      #FuncUnique()
+      """
+    } expansion: {
+      """
+      class MyClass {
+        func __macro_local_6uniquefMu_() {
+        }
+      }
+      """
+    }
+  }
+}

--- a/Tests/MacroTestingTests/IndentationWidthTests.swift
+++ b/Tests/MacroTestingTests/IndentationWidthTests.swift
@@ -1,0 +1,116 @@
+import MacroTesting
+import SwiftSyntax
+import SwiftSyntaxMacros
+import XCTest
+
+private struct AddMemberMacro: MemberMacro {
+  static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return ["let v: T"]
+  }
+}
+
+final class IndentationWidthTests: XCTestCase {
+  func testExpansionAddsMemberUsingDetectedIndentation() {
+    assertMacro([AddMemberMacro.self]) {
+      """
+      @AddMember
+      struct S {
+        let w: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        let w: T
+
+        let v: T
+      }
+      """
+    }
+  }
+
+  func testExpansionAddsMemberToEmptyStructUsingDefaultIndentation() {
+    assertMacro([AddMemberMacro.self]) {
+      """
+      @AddMember
+      struct S {
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+
+          let v: T
+      }
+      """
+    }
+  }
+
+  func testExpansionAddsMemberToEmptyStructUsingTwoSpaceIndentation() {
+    assertMacro(
+      [AddMemberMacro.self],
+      indentationWidth: .spaces(2)
+    ) {
+      """
+      @AddMember
+      struct S {
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+
+        let v: T
+      }
+      """
+    }
+  }
+
+  func testExpansionAddsMemberToEmptyStructUsingTwoSpaceIndentation_withMacroTesting() {
+    withMacroTesting(
+      indentationWidth: .spaces(2),
+      macros: [AddMemberMacro.self]
+    ) {
+      assertMacro {
+        """
+        @AddMember
+        struct S {
+        }
+        """
+      } expansion: {
+        """
+        struct S {
+
+          let v: T
+        }
+        """
+      }
+    }
+  }
+
+  func testExpansionAddsMemberUsingMistchedIndentation() {
+    assertMacro(
+      [AddMemberMacro.self],
+      indentationWidth: .spaces(4)
+    ) {
+      """
+      @AddMember
+      struct S {
+        let w: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        let w: T
+
+          let v: T
+      }
+      """
+    }
+  }
+}

--- a/Tests/MacroTestingTests/MacroAttributeDiagnosticTests.swift
+++ b/Tests/MacroTestingTests/MacroAttributeDiagnosticTests.swift
@@ -1,0 +1,384 @@
+//// Come back and check this work after two PRs land or are otherwise resolved:
+//// - Update FixItApplier
+//// - Multi-FixIt support
+//
+//import MacroTesting
+//import SwiftDiagnostics
+//import SwiftSyntax
+//import SwiftSyntaxBuilder
+//import SwiftSyntaxMacros
+//import SwiftSyntaxMacrosTestSupport
+//import XCTest
+//
+//private struct Index {
+//  private static var index = 0
+//
+//  static var next: Int {
+//    defer { index += 1 }
+//    return index
+//  }
+//}
+//
+//extension Diagnostic {
+//  fileprivate static func error(on node: AttributeSyntax, fixIts: [FixIt] = []) -> Self {
+//    let index = Index.next
+//    return Diagnostic(
+//      node: node.attributeName,
+//      message: SimpleDiagnosticMessage(
+//        message: "This is an error diagnostic (#\(index)).",
+//        diagnosticID: MessageID(domain: "domain", id: "diagnostic\(index)"),
+//        severity: .error
+//      ),
+//      fixIts: fixIts
+//    )
+//  }
+//
+//  fileprivate static func note(on node: AttributeSyntax) -> Self {
+//    let index = Index.next
+//    return Diagnostic(
+//      node: node.attributeName,
+//      message: SimpleDiagnosticMessage(
+//        message: "This is a note diagnostic (#\(index)).",
+//        diagnosticID: MessageID(domain: "domain", id: "diagnostic(#\(index)"),
+//        severity: .note
+//      )
+//    )
+//  }
+//
+//  fileprivate static func warning(on node: AttributeSyntax, fixIts: [FixIt] = []) -> Self {
+//    let index = Index.next
+//    return Diagnostic(
+//      node: node.attributeName,
+//      message: SimpleDiagnosticMessage(
+//        message: "This is a warning diagnostic (#\(index)).",
+//        diagnosticID: MessageID(domain: "domain", id: "diagnostic\(index)"),
+//        severity: .warning
+//      ),
+//      fixIts: fixIts
+//    )
+//  }
+//
+//}
+//
+//extension FixIt {
+//  fileprivate static func error(on node: Syntax) -> Self {
+//    let index = Index.next
+//    return FixIt(
+//      message: SimpleDiagnosticMessage(
+//        message: "This is a fix-it (#\(index)).",
+//        diagnosticID: MessageID(domain: "domain", id: "fixit#\(index)"),
+//        severity: .error
+//      ),
+//      changes: [
+//        .replace(oldNode: Syntax(node), newNode: Syntax(node))  // no-op
+//      ]
+//    )
+//  }
+//
+//  fileprivate static func error(on node: SyntaxProtocol) -> Self {
+//    error(on: Syntax(node))
+//  }
+//}
+//
+//final class DiagnosticTests: XCTestCase {
+//  func testDiagnosticFixit() {
+//    enum TestMacro: MemberMacro {
+//      public static func expansion(
+//        of node: AttributeSyntax,
+//        providingMembersOf declaration: some DeclGroupSyntax,
+//        in context: some MacroExpansionContext
+//      ) throws -> [DeclSyntax] {
+//        context.diagnose(
+//          .error(
+//            on: node,
+//            fixIts: [.error(on: node)]  // 👈 will crash with a fixit
+//            //            fixIts: [.error(on: declaration)]  // 👈 also crashes
+//          )
+//        )
+//
+//        return []
+//      }
+//    }
+//
+//    // 🛑 🛑 🛑 When given an "expansion" and macro emits a fixit, `assertMacro` will crash.
+//    assertMacro([TestMacro.self]) {
+//      """
+//      @Test
+//      struct S {}
+//      """
+//    } expansion: {
+//      """
+//      struct S {}
+//      """
+//    }
+//  }
+//
+//  func testDiagnosticFixit2() {
+//    enum TestMacro: MemberMacro {
+//      public static func expansion(
+//        of node: AttributeSyntax,
+//        providingMembersOf declaration: some DeclGroupSyntax,
+//        in context: some MacroExpansionContext
+//      ) throws -> [DeclSyntax] {
+//        context.diagnose(
+//          .error(
+//            on: node,
+//            fixIts: [.error(on: node)]  // 👈 fixit
+//          )
+//        )
+//
+//        return []
+//      }
+//    }
+//
+//    // 🛑 `assertMacro` expands with a blank "expansion" string instead of containing "struct S {}".
+//    assertMacro([TestMacro.self]) {
+//      """
+//      @Test
+//      struct S {}
+//      """
+//      //    } diagnostics: {
+//      //      """
+//      //      @Test
+//      //       ┬───
+//      //       ╰─ 🛑 This is an error diagnostic (#1).
+//      //          ✏️ This is a fix-it (#0).
+//      //      struct S {}
+//      //      """
+//      //    } fixes: {
+//      //      """
+//      //      @Test
+//      //      """
+//      //    } expansion: {
+//      //      """
+//      //
+//      //      """
+//    }
+//  }
+//
+//  func testDiagnosticFixitNote() {
+//    enum TestMacro: MemberMacro {
+//      public static func expansion(
+//        of node: AttributeSyntax,
+//        providingMembersOf declaration: some DeclGroupSyntax,
+//        in context: some MacroExpansionContext
+//      ) throws -> [DeclSyntax] {
+//        context.diagnose(
+//          .error(
+//            on: node,
+//            fixIts: [.error(on: node)]  // 👈 fixit
+//          )
+//        )
+//        context.diagnose(
+//          .note(on: node)  // 👈 note
+//        )
+//
+//        return []
+//      }
+//    }
+//
+//    // `assertMacro` expands with just "diagnostics", omitting "fixes" and "expansion".
+//    assertMacro([TestMacro.self]) {
+//      """
+//      @Test
+//      struct S {}
+//      """
+//      //    } diagnostics: {
+//      //      """
+//      //      @Test
+//      //       ┬───
+//      //       ├─ 🛑 This is an error diagnostic (#1).
+//      //       │  ✏️ This is a fix-it (#0).
+//      //       ╰─ ℹ️ This is a note diagnostic (#2).
+//      //      struct S {}
+//      //      """
+//    }
+//  }
+//
+//  // This test match the emissions of `DiagnosticsAndFixitsEmitterMacro`, and demonstrates
+//  // that `assertMacro` behaves the same with this test setup.
+//  func testMirrorDiagnosticsAndFixitsEmitterMacro() {
+//    enum TestMacro: MemberMacro {
+//      public static func expansion(
+//        of node: AttributeSyntax,
+//        providingMembersOf declaration: some DeclGroupSyntax,
+//        in context: some MacroExpansionContext
+//      ) throws -> [DeclSyntax] {
+//        context.diagnose(
+//          .warning(  // change this to `.error` to only get "diagnostics" instead of "diagnostics" and "expansion". Either way, no "fixes".
+//            on: node,
+//            fixIts: [
+//              .error(on: node),
+//              .error(on: node),
+//            ]
+//          )
+//        )
+//        context.diagnose(
+//          .note(on: node)
+//        )
+//
+//        return []
+//      }
+//    }
+//
+//    assertMacro([TestMacro.self]) {
+//      """
+//      @Test
+//      struct S {}
+//      """
+//      //    } diagnostics: {
+//      //      """
+//      //      @Test
+//      //       ┬───
+//      //       ├─ ⚠️ This is a warning diagnostic (#2).
+//      //       │  ✏️ This is a fix-it (#0).
+//      //       │  ✏️ This is a fix-it (#1).
+//      //       ╰─ ℹ️ This is a note diagnostic (#3).
+//      //      struct S {}
+//      //      """
+//      //    } expansion: {
+//      //      """
+//      //      struct S {}
+//      //      """
+//    }
+//  }
+//
+//  // The actual DiagnosticsAndFixitsEmitterMacro, for comparison to above.
+//  func testDiagnosticsAndFixitsEmitterMacro() {
+//    assertMacro([DiagnosticsAndFixitsEmitterMacro.self]) {
+//      """
+//      @DiagnosticsAndFixitsEmitter
+//      struct S {}
+//      """
+//      //    } diagnostics: {
+//      //      """
+//      //      @DiagnosticsAndFixitsEmitter
+//      //       ┬──────────────────────────
+//      //       ├─ ⚠️ This is the first diagnostic.
+//      //       │  ✏️ This is the first fix-it.
+//      //       │  ✏️ This is the second fix-it.
+//      //       ╰─ ℹ️ This is the second diagnostic, it's a note.
+//      //      struct S {}
+//      //      """
+//      //    } expansion: {
+//      //      """
+//      //      struct S {}
+//      //      """
+//    }
+//  }
+//
+//  // `SwiftSyntaxMacrosTestSupport.assertMacroExpansion` works as expected.
+//  // (The compiler/Xcode also work as expected.)
+//  func testDiagnosticFixit_assertMacroExpansion() {
+//    enum TestMacro: MemberMacro {
+//      public static func expansion(
+//        of node: AttributeSyntax,
+//        providingMembersOf declaration: some DeclGroupSyntax,
+//        in context: some MacroExpansionContext
+//      ) throws -> [DeclSyntax] {
+//        context.diagnose(
+//          .error(
+//            on: node,
+//            fixIts: [.error(on: node)]  // 👈 fixit
+//          )
+//        )
+//
+//        return []
+//      }
+//    }
+//
+//    assertMacroExpansion(
+//      """
+//      @Test
+//      struct S {}
+//      """,
+//      expandedSource: """
+//        struct S {}
+//        """,
+//      diagnostics: [
+//        DiagnosticSpec(
+//          message: "This is an error diagnostic (#1).",
+//          line: 1,
+//          column: 2,
+//          fixIts: [
+//            FixItSpec(message: "This is a fix-it (#0).")
+//          ]
+//        )
+//      ],
+//      macros: [
+//        "Test": TestMacro.self
+//      ]
+//    )
+//  }
+//
+//  // This test shows awkward but expected behavior, given the bug that the "expansion" is empty.
+//  func testDiagnostic() {
+//    enum TestMacro: MemberMacro {
+//      public static func expansion(
+//        of node: AttributeSyntax,
+//        providingMembersOf declaration: some DeclGroupSyntax,
+//        in context: some MacroExpansionContext
+//      ) throws -> [DeclSyntax] {
+//        context.diagnose(
+//          .error(on: node)  // 👈 no fixit
+//        )
+//
+//        return []
+//      }
+//    }
+//
+//    // Bug: Expanding `assertMacro` omits the "expansion".
+//    assertMacro([TestMacro.self]) {
+//      """
+//      @Test
+//      struct S {}
+//      """
+//      //    } diagnostics: {
+//      //      """
+//      //      @Test
+//      //       ┬───
+//      //       ╰─ 🛑 This is an error diagnostic (#0).
+//      //      struct S {}
+//      //      """
+//    }
+//
+//    // `assertMacro` expands as expected when given the correct "expansion".
+//    assertMacro([TestMacro.self]) {
+//      """
+//      @Test
+//      struct S {}
+//      """
+//      //    } diagnostics: {
+//      //      """
+//      //      @Test
+//      //       ┬───
+//      //       ╰─ 🛑 This is an error diagnostic (#1).
+//      //      struct S {}
+//      //      """
+//    } expansion: {
+//      """
+//      struct S {}
+//      """
+//    }
+//
+//    // 🛑 `assertMacro` test failure: : 'failed - Expected macro expansion, but there was none'
+//    assertMacro([TestMacro.self]) {
+//      """
+//      @Test
+//      struct S {}
+//      """
+//    } diagnostics: {
+//      """
+//      @Test
+//       ┬───
+//       ╰─ 🛑 This is an error diagnostic (#0).
+//      struct S {}
+//      """
+//    } expansion: {
+//      """
+//      struct S {}
+//      """
+//    }
+//  }
+//
+//}

--- a/Tests/MacroTestingTests/MacroAttributeDiagnosticTests2.swift
+++ b/Tests/MacroTestingTests/MacroAttributeDiagnosticTests2.swift
@@ -1,0 +1,281 @@
+//// Come back and check this work after two PRs land or are otherwise resolved:
+//// - Update FixItApplier
+//// - Multi-FixIt support
+
+//import MacroTesting
+//import SwiftDiagnostics
+//import SwiftSyntax
+//import SwiftSyntaxBuilder
+//import SwiftSyntaxMacros
+//import SwiftSyntaxMacrosTestSupport
+//import XCTest
+//
+//// TODO: i am here
+//// This doesn't actually have to do with the diagnostic being on the AttributeSyntax node, as I originally though.
+//// This has to do with the combination of diagnostics/types/severities.
+//// For example, adding a "note" changes the behavior, but not completely.
+//// It actually fixes the crash, but the expansion is still wrong.
+////
+//// Need to show permutations/combinations:
+//// - Diagnostic
+//// - Diagnostic, FixIt
+//// - Diagnostic, FixIt, Note
+//
+//// Change tests to this style, to ease undertanding of what's being tested
+///*
+//enum TestMacro: MemberMacro {
+//  public static func expansion(
+//    of node: AttributeSyntax,
+//    providingMembersOf declaration: some DeclGroupSyntax,
+//    in context: some MacroExpansionContext
+//  ) throws -> [DeclSyntax] {
+////        context.diagnose(.error)
+////        context.diagnose(.errorWithFixit)
+////        context.diagnose(.errorWithFixit + .note)
+////        context.diagnose(.warning)
+////        context.diagnose(.warningWithFixit)
+////        context.diagnose(.warningWithFixit + .note)
+//
+// //        context.diagnose(.error)
+// //        context.diagnose(.error(fixit: .error) + .note)
+// //        context.diagnose(.error(fixit: .error))
+// //        context.diagnose(.error(fixit: .warning))
+// //        context.diagnose(.error(fixit: .warning) + .note)
+//
+// //        context.diagnose(.warning)
+// //        context.diagnose(.warning(fixit: .error) + .note)
+// //        context.diagnose(.warning(fixit: .error))
+// //        context.diagnose(.warning(fixit: .warning))
+// //        context.diagnose(.warning(fixit: .warning) + .note)
+//
+//    return []
+//  }
+//}
+//*/
+//
+//enum MacroAttributeDiagnosticEmitterMacro2: MemberMacro {
+//  public static func expansion(
+//    of node: AttributeSyntax,
+//    providingMembersOf declaration: some DeclGroupSyntax,
+//    in context: some MacroExpansionContext
+//  ) throws -> [DeclSyntax] {
+//    context.diagnose(
+//      Diagnostic(
+//        node: node.attributeName,
+//        message: SimpleDiagnosticMessage(
+//          message: "This is the first diagnostic.",
+//          diagnosticID: MessageID(domain: "domain", id: "diagnostic1"),
+//          severity: .error
+//        )
+//      )
+//    )
+//
+//    return []
+//  }
+//}
+//
+//enum MacroAttributeDiagnosticAndFixitEmitterMacro2: MemberMacro {
+//  public static func expansion(
+//    of node: AttributeSyntax,
+//    providingMembersOf declaration: some DeclGroupSyntax,
+//    in context: some MacroExpansionContext
+//  ) throws -> [DeclSyntax] {
+//    let firstFixIt = FixIt(
+//      message: SimpleDiagnosticMessage(
+//        message: "This is the first fix-it.",
+//        diagnosticID: MessageID(domain: "domain", id: "fixit"),
+//        severity: .warning
+//      ),
+//      changes: [
+//        //        .replace(oldNode: Syntax(declaration), newNode: Syntax(declaration))  // no-op, testMacroAttributeDiagnosticAndFixitEmitter still crashes
+//        .replace(oldNode: Syntax(node), newNode: Syntax(node))  // no-op
+//      ]
+//    )
+//
+//    context.diagnose(
+//      Diagnostic(
+//        node: node.attributeName,
+//        message: SimpleDiagnosticMessage(
+//          message: "This is the first diagnostic.",
+//          diagnosticID: MessageID(domain: "domain", id: "diagnostic2"),
+//          severity: .error
+//        ),
+//        fixIts: [firstFixIt]
+//      )
+//    )
+//    //    context.diagnose(
+//    //      Diagnostic(
+//    //        node: node.attributeName,
+//    //        message: SimpleDiagnosticMessage(
+//    //          message: "This is the second diagnostic, it's a note.",
+//    //          diagnosticID: MessageID(domain: "domain", id: "diagnostic3"),
+//    //          severity: .note)))
+//
+//    return []
+//  }
+//}
+//
+//final class MacroAttributeDiagnosticTests2: XCTestCase {
+//  // No fixit, with prexisting "expansion": no crash.
+//  // See next `testMacroAttributeDiagnosticEmitter_After` for expanded `assertMacro`.
+//  func testMacroAttributeDiagnosticEmitter_Before() {
+//    assertMacro([MacroAttributeDiagnosticEmitterMacro2.self]) {
+//      """
+//      @MacroAttributeDiagnosticEmitter
+//      struct S {
+//      }
+//      """
+//    } expansion: {
+//      """
+//      struct S {
+//      }
+//      """
+//    }
+//  }
+//
+//  // Correctly expanded `assertMacro` from above `testMacroAttributeDiagnosticEmitter_Before`.
+//  // But, this test fails: 'failed - Expected macro expansion, but there was none'
+//  func testMacroAttributeDiagnosticEmitter_After() {
+//    assertMacro([MacroAttributeDiagnosticEmitterMacro2.self]) {
+//      """
+//      @MacroAttributeDiagnosticEmitter
+//      struct S {
+//      }
+//      """
+//    } diagnostics: {
+//      """
+//      @MacroAttributeDiagnosticEmitter
+//       ┬──────────────────────────────
+//       ╰─ 🛑 This is the first diagnostic.
+//      struct S {
+//      }
+//      """
+//    } expansion: {
+//      """
+//      struct S {
+//      }
+//      """
+//    }
+//  }
+//
+//  // 🛑 🛑 🛑 Will crash
+//  // Has fixit and existing "expansion", so it will crash.
+//  func testMacroAttributeDiagnosticAndFixitEmitter() {
+//    assertMacro([MacroAttributeDiagnosticAndFixitEmitterMacro2.self]) {
+//      """
+//      @MacroAttributeDiagnosticAndFixitEmitter
+//      struct S {
+//      }
+//      """
+//    } expansion: {
+//      """
+//      struct S {
+//      }
+//      """
+//    }
+//  }
+//
+//  // TODO: This assertMacro expands correctly, despite preexisting expansion ...wha?
+//  // And after it expands correctly, it passes.
+//  // This must be a huge clue.
+//  // Maybe because it has not diagnostics of "error" severity? I don't think so?
+//  //  DiagnosticsAndFixitsEmitterMacro
+//  func testMacroAttributeDiagnosticAndFixitEmitterASDF() {
+//    assertMacro([DiagnosticsAndFixitsEmitterMacro.self]) {
+//      """
+//      @DiagnosticsAndFixitsEmitter
+//      struct S {
+//      }
+//      """
+//      //    } diagnostics: {
+//      //      """
+//      //      @DiagnosticsAndFixitsEmitter
+//      //       ┬──────────────────────────
+//      //       ├─ ⚠️ This is the first diagnostic.
+//      //       │  ✏️ This is the first fix-it.
+//      //       │  ✏️ This is the second fix-it.
+//      //       ╰─ ℹ️ This is the second diagnostic, it's a note.
+//      //      struct S {
+//      //      }
+//      //      """
+//    } expansion: {
+//      """
+//      struct S {
+//      }
+//      """
+//    }
+//  }
+//
+//  // Here, `assertMacro` expands but is wrong: "expansion" is blank.
+//  // * See next `testMacroAttributeDiagnosticAndFixitEmitter_After` for expanded `assertMacro`.
+//  func testMacroAttributeDiagnosticAndFixitEmitter_Before() {
+//    assertMacro([MacroAttributeDiagnosticAndFixitEmitterMacro2.self]) {
+//      """
+//      @MacroAttributeDiagnosticAndFixitEmitter
+//      struct S {
+//      }
+//      """
+//    }
+//  }
+//
+//  // Incorrectly expanded `assertMacro` from above `testMacroAttributeDiagnosticAndFixitEmitter_Before`.
+//  // * In this state, the test doesn't crash (and passes).
+//  // * If you manually add the correct non-blank "expansion", the test will fail because it
+//  //   differs from blank but it won't crash.
+//  func testMacroAttributeDiagnosticAndFixitEmitter_After() {
+//    assertMacro([MacroAttributeDiagnosticAndFixitEmitterMacro2.self]) {
+//      """
+//      @MacroAttributeDiagnosticAndFixitEmitter
+//      struct S {
+//      }
+//      """
+//    } diagnostics: {
+//      """
+//      @MacroAttributeDiagnosticAndFixitEmitter
+//       ┬──────────────────────────────────────
+//       ╰─ 🛑 This is the first diagnostic.
+//          ✏️ This is the first fix-it.
+//      struct S {
+//      }
+//      """
+//    } fixes: {
+//      """
+//      @MacroAttributeDiagnosticAndFixitEmitter
+//      """
+//    } expansion: {
+//      """
+//
+//      """
+//    }
+//  }
+//
+//  // `SwiftSyntaxMacrosTestSupport.assertMacroExpansion` works as expected.
+//  // (The compiler/Xcode also work as expected.)
+//  func testMacroAttributeDiagnosticAndFixitEmitter_assertMacroExpansion() {
+//    assertMacroExpansion(
+//      """
+//      @MacroAttributeDiagnosticAndFixitEmitter
+//      struct S {
+//      }
+//      """,
+//      expandedSource: """
+//        struct S {
+//        }
+//        """,
+//      diagnostics: [
+//        DiagnosticSpec(
+//          message: "This is the first diagnostic.",
+//          line: 1,
+//          column: 2,
+//          fixIts: [
+//            FixItSpec(message: "This is the first fix-it.")
+//          ]
+//        )
+//      ],
+//      macros: [
+//        "MacroAttributeDiagnosticAndFixitEmitter": MacroAttributeDiagnosticAndFixitEmitterMacro2
+//          .self
+//      ]
+//    )
+//  }
+//}

--- a/Tests/MacroTestingTests/MacroExamples/AddAsyncMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/AddAsyncMacro.swift
@@ -1,0 +1,175 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+extension SyntaxCollection {
+  mutating func removeLast() {
+    self.remove(at: self.index(before: self.endIndex))
+  }
+}
+
+public struct AddAsyncMacro: PeerMacro {
+  public static func expansion<
+    Context: MacroExpansionContext,
+    Declaration: DeclSyntaxProtocol
+  >(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: Declaration,
+    in context: Context
+  ) throws -> [DeclSyntax] {
+
+    // Only on functions at the moment.
+    guard let funcDecl = declaration.as(FunctionDeclSyntax.self) else {
+      throw CustomError.message("@addAsync only works on functions")
+    }
+
+    // This only makes sense for non async functions.
+    if funcDecl.signature.effectSpecifiers?.asyncSpecifier != nil {
+      throw CustomError.message(
+        "@addAsync requires an non async function"
+      )
+    }
+
+    // This only makes sense void functions
+    if funcDecl.signature.returnClause?.type.with(\.leadingTrivia, []).with(\.trailingTrivia, [])
+      .description != "Void"
+    {
+      throw CustomError.message(
+        "@addAsync requires an function that returns void"
+      )
+    }
+
+    // Requires a completion handler block as last parameter
+    guard
+      let completionHandlerParameterAttribute = funcDecl.signature.parameterClause.parameters.last?
+        .type.as(AttributedTypeSyntax.self),
+      let completionHandlerParameter = completionHandlerParameterAttribute.baseType.as(
+        FunctionTypeSyntax.self)
+    else {
+      throw CustomError.message(
+        "@addAsync requires an function that has a completion handler as last parameter"
+      )
+    }
+
+    // Completion handler needs to return Void
+    if completionHandlerParameter.returnClause.type.with(\.leadingTrivia, []).with(
+      \.trailingTrivia, []
+    ).description != "Void" {
+      throw CustomError.message(
+        "@addAsync requires an function that has a completion handler that returns Void"
+      )
+    }
+
+    let returnType = completionHandlerParameter.parameters.first?.type
+
+    let isResultReturn = returnType?.children(viewMode: .all).first?.description == "Result"
+    let successReturnType =
+      isResultReturn
+      ? returnType!.as(IdentifierTypeSyntax.self)!.genericArgumentClause?.arguments.first!.argument
+      : returnType
+
+    // Remove completionHandler and comma from the previous parameter
+    var newParameterList = funcDecl.signature.parameterClause.parameters
+    newParameterList.removeLast()
+    let newParameterListLastParameter = newParameterList.last!
+    newParameterList.removeLast()
+    newParameterList.append(
+      newParameterListLastParameter.with(\.trailingTrivia, []).with(\.trailingComma, nil))
+
+    // Drop the @addAsync attribute from the new declaration.
+    let newAttributeList = funcDecl.attributes.filter {
+      guard case let .attribute(attribute) = $0,
+        let attributeType = attribute.attributeName.as(IdentifierTypeSyntax.self),
+        let nodeType = node.attributeName.as(IdentifierTypeSyntax.self)
+      else {
+        return true
+      }
+
+      return attributeType.name.text != nodeType.name.text
+    }
+
+    let callArguments: [String] = newParameterList.map { param in
+      let argName = param.secondName ?? param.firstName
+
+      let paramName = param.firstName
+      if paramName.text != "_" {
+        return "\(paramName.text): \(argName.text)"
+      }
+
+      return "\(argName.text)"
+    }
+
+    let switchBody: ExprSyntax =
+      """
+            switch returnValue {
+            case .success(let value):
+              continuation.resume(returning: value)
+            case .failure(let error):
+              continuation.resume(throwing: error)
+            }
+      """
+
+    let newBody: ExprSyntax =
+      """
+
+        \(raw: isResultReturn ? "try await withCheckedThrowingContinuation { continuation in" : "await withCheckedContinuation { continuation in")
+          \(raw: funcDecl.name)(\(raw: callArguments.joined(separator: ", "))) { \(raw: returnType != nil ? "returnValue in" : "")
+
+      \(raw: isResultReturn ? switchBody : "continuation.resume(returning: \(raw: returnType != nil ? "returnValue" : "()"))")
+          }
+        }
+
+      """
+
+    let newFunc =
+      funcDecl
+      .with(
+        \.signature,
+        funcDecl.signature
+          .with(
+            \.effectSpecifiers,
+            FunctionEffectSpecifiersSyntax(
+              leadingTrivia: .space,
+              asyncSpecifier: .keyword(.async),
+              throwsSpecifier: isResultReturn ? .keyword(.throws) : nil
+            )  // add async
+          )
+          .with(
+            \.returnClause,
+            successReturnType != nil
+              ? ReturnClauseSyntax(
+                leadingTrivia: .space, type: successReturnType!.with(\.leadingTrivia, .space)) : nil
+          )  // add result type
+          .with(
+            \.parameterClause,
+            funcDecl.signature.parameterClause.with(\.parameters, newParameterList)  // drop completion handler
+              .with(\.trailingTrivia, [])
+          )
+      )
+      .with(
+        \.body,
+        CodeBlockSyntax(
+          leftBrace: .leftBraceToken(leadingTrivia: .space),
+          statements: CodeBlockItemListSyntax(
+            [CodeBlockItemSyntax(item: .expr(newBody))]
+          ),
+          rightBrace: .rightBraceToken(leadingTrivia: .newline)
+        )
+      )
+      .with(\.attributes, newAttributeList)
+      .with(\.leadingTrivia, .newlines(2))
+
+    return [DeclSyntax(newFunc)]
+  }
+}

--- a/Tests/MacroTestingTests/MacroExamples/AddBlocker.swift
+++ b/Tests/MacroTestingTests/MacroExamples/AddBlocker.swift
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftOperators
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Implementation of the `addBlocker` macro, which demonstrates how to
+/// produce detailed diagnostics from a macro implementation for an utterly
+/// silly task: warning about every "add" (binary +) in the argument, with a
+/// Fix-It that changes it to a "-".
+public struct AddBlocker: ExpressionMacro {
+  class AddVisitor: SyntaxRewriter {
+    var diagnostics: [Diagnostic] = []
+
+    override func visit(
+      _ node: InfixOperatorExprSyntax
+    ) -> ExprSyntax {
+      // Identify any infix operator + in the tree.
+      if let binOp = node.operator.as(BinaryOperatorExprSyntax.self) {
+        if binOp.operator.text == "+" {
+          // Form the warning
+          let messageID = MessageID(domain: "silly", id: "addblock")
+          diagnostics.append(
+            Diagnostic(
+              // Where the warning should go (on the "+").
+              node: Syntax(node.operator),
+              // The warning message and severity.
+              message: SimpleDiagnosticMessage(
+                message: "blocked an add; did you mean to subtract?",
+                diagnosticID: messageID,
+                severity: .warning
+              ),
+              // Highlight the left and right sides of the `+`.
+              highlights: [
+                Syntax(node.leftOperand),
+                Syntax(node.rightOperand),
+              ],
+              fixIts: [
+                // Fix-It to replace the '+' with a '-'.
+                FixIt(
+                  message: SimpleDiagnosticMessage(
+                    message: "use '-'",
+                    diagnosticID: messageID,
+                    severity: .error
+                  ),
+                  changes: [
+                    FixIt.Change.replace(
+                      oldNode: Syntax(binOp.operator),
+                      newNode: Syntax(
+                        TokenSyntax(
+                          .binaryOperator("-"),
+                          leadingTrivia: binOp.operator.leadingTrivia,
+                          trailingTrivia: binOp.operator.trailingTrivia,
+                          presence: .present
+                        )
+                      )
+                    )
+                  ]
+                )
+              ]
+            )
+          )
+
+          return ExprSyntax(
+            node.with(
+              \.operator,
+              ExprSyntax(
+                binOp.with(
+                  \.operator,
+                  binOp.operator.with(\.tokenKind, .binaryOperator("-"))
+                )
+              )
+            )
+          )
+        }
+      }
+
+      return ExprSyntax(node)
+    }
+  }
+
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> ExprSyntax {
+    let visitor = AddVisitor()
+    let result = visitor.rewrite(Syntax(node))
+
+    for diag in visitor.diagnostics {
+      context.diagnose(diag)
+    }
+
+    return result.asProtocol(FreestandingMacroExpansionSyntax.self)!.argumentList.first!.expression
+  }
+}

--- a/Tests/MacroTestingTests/MacroExamples/AddCompletionHandlerMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/AddCompletionHandlerMacro.swift
@@ -1,0 +1,171 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct AddCompletionHandlerMacro: PeerMacro {
+  public static func expansion<
+    Context: MacroExpansionContext,
+    Declaration: DeclSyntaxProtocol
+  >(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: Declaration,
+    in context: Context
+  ) throws -> [DeclSyntax] {
+    // Only on functions at the moment. We could handle initializers as well
+    // with a bit of work.
+    guard let funcDecl = declaration.as(FunctionDeclSyntax.self) else {
+      throw CustomError.message("@addCompletionHandler only works on functions")
+    }
+
+    // This only makes sense for async functions.
+    if funcDecl.signature.effectSpecifiers?.asyncSpecifier == nil {
+      let newEffects: FunctionEffectSpecifiersSyntax
+      if let existingEffects = funcDecl.signature.effectSpecifiers {
+        newEffects = existingEffects.with(\.asyncSpecifier, .keyword(.async))
+      } else {
+        newEffects = FunctionEffectSpecifiersSyntax(asyncSpecifier: .keyword(.async))
+      }
+
+      let newSignature = funcDecl.signature.with(\.effectSpecifiers, newEffects)
+      let messageID = MessageID(domain: "MacroExamples", id: "MissingAsync")
+
+      let diag = Diagnostic(
+        // Where the error should go (on the "+").
+        node: Syntax(funcDecl.funcKeyword),
+        // The warning message and severity.
+        message: SimpleDiagnosticMessage(
+          message: "can only add a completion-handler variant to an 'async' function",
+          diagnosticID: messageID,
+          severity: .error
+        ),
+        fixIts: [
+          // Fix-It to replace the '+' with a '-'.
+          FixIt(
+            message: SimpleDiagnosticMessage(
+              message: "add 'async'",
+              diagnosticID: messageID,
+              severity: .error
+            ),
+            changes: [
+              FixIt.Change.replace(
+                oldNode: Syntax(funcDecl.signature),
+                newNode: Syntax(newSignature)
+              )
+            ]
+          )
+        ]
+      )
+
+      context.diagnose(diag)
+      return []
+    }
+
+    // Form the completion handler parameter.
+    let resultType: TypeSyntax? = funcDecl.signature.returnClause?.type.with(\.leadingTrivia, [])
+      .with(\.trailingTrivia, [])
+
+    let completionHandlerParam =
+      FunctionParameterSyntax(
+        firstName: .identifier("completionHandler"),
+        colon: .colonToken(trailingTrivia: .space),
+        type: "@escaping (\(resultType ?? "")) -> Void" as TypeSyntax
+      )
+
+    // Add the completion handler parameter to the parameter list.
+    let parameterList = funcDecl.signature.parameterClause.parameters
+    var newParameterList = parameterList
+    if let lastParam = parameterList.last {
+      // We need to add a trailing comma to the preceding list.
+      newParameterList.removeLast()
+      newParameterList += [
+        lastParam.with(
+          \.trailingComma,
+          .commaToken(trailingTrivia: .space)
+        ),
+        completionHandlerParam,
+      ]
+    } else {
+      newParameterList.append(completionHandlerParam)
+    }
+
+    let callArguments: [String] = parameterList.map { param in
+      let argName = param.secondName ?? param.firstName
+
+      let paramName = param.firstName
+      if paramName.text != "_" {
+        return "\(paramName.text): \(argName.text)"
+      }
+
+      return "\(argName.text)"
+    }
+
+    let call: ExprSyntax =
+      "\(funcDecl.name)(\(raw: callArguments.joined(separator: ", ")))"
+
+    // FIXME: We should make CodeBlockSyntax ExpressibleByStringInterpolation,
+    // so that the full body could go here.
+    let newBody: ExprSyntax =
+      """
+
+        Task {
+          completionHandler(await \(call))
+        }
+
+      """
+
+    // Drop the @addCompletionHandler attribute from the new declaration.
+    let newAttributeList = funcDecl.attributes.filter {
+      guard case let .attribute(attribute) = $0,
+        let attributeType = attribute.attributeName.as(IdentifierTypeSyntax.self),
+        let nodeType = node.attributeName.as(IdentifierTypeSyntax.self)
+      else {
+        return true
+      }
+
+      return attributeType.name.text != nodeType.name.text
+    }
+
+    let newFunc =
+      funcDecl
+      .with(
+        \.signature,
+        funcDecl.signature
+          .with(
+            \.effectSpecifiers,
+            funcDecl.signature.effectSpecifiers?.with(\.asyncSpecifier, nil)  // drop async
+          )
+          .with(\.returnClause, nil)  // drop result type
+          .with(
+            \.parameterClause,  // add completion handler parameter
+            funcDecl.signature.parameterClause.with(\.parameters, newParameterList)
+              .with(\.trailingTrivia, [])
+          )
+      )
+      .with(
+        \.body,
+        CodeBlockSyntax(
+          leftBrace: .leftBraceToken(leadingTrivia: .space),
+          statements: CodeBlockItemListSyntax(
+            [CodeBlockItemSyntax(item: .expr(newBody))]
+          ),
+          rightBrace: .rightBraceToken(leadingTrivia: .newline)
+        )
+      )
+      .with(\.attributes, newAttributeList)
+      .with(\.leadingTrivia, .newlines(2))
+
+    return [DeclSyntax(newFunc)]
+  }
+}

--- a/Tests/MacroTestingTests/MacroExamples/CaseDetectionMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/CaseDetectionMacro.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public enum CaseDetectionMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    declaration.memberBlock.members
+      .compactMap { $0.decl.as(EnumCaseDeclSyntax.self) }
+      .map { $0.elements.first!.name }
+      .map { ($0, $0.initialUppercased) }
+      .map { original, uppercased in
+        """
+        var is\(raw: uppercased): Bool {
+          if case .\(raw: original) = self {
+            return true
+          }
+
+          return false
+        }
+        """
+      }
+  }
+}
+
+extension TokenSyntax {
+  fileprivate var initialUppercased: String {
+    let name = self.text
+    guard let initial = name.first else {
+      return name
+    }
+
+    return "\(initial.uppercased())\(name.dropFirst())"
+  }
+}

--- a/Tests/MacroTestingTests/MacroExamples/CustomCodable.swift
+++ b/Tests/MacroTestingTests/MacroExamples/CustomCodable.swift
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public enum CustomCodable: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let memberList = declaration.memberBlock.members
+
+    let cases = memberList.compactMap({ member -> String? in
+      // is a property
+      guard
+        let propertyName = member.decl.as(VariableDeclSyntax.self)?.bindings.first?.pattern.as(
+          IdentifierPatternSyntax.self)?.identifier.text
+      else {
+        return nil
+      }
+
+      // if it has a CodableKey macro on it
+      if let customKeyMacro = member.decl.as(VariableDeclSyntax.self)?.attributes.first(where: {
+        element in
+        element.as(AttributeSyntax.self)?.attributeName.as(IdentifierTypeSyntax.self)?.description
+          == "CodableKey"
+      }) {
+
+        // Uses the value in the Macro
+        let customKeyValue = customKeyMacro.as(AttributeSyntax.self)!.arguments!.as(
+          LabeledExprListSyntax.self)!.first!.expression
+
+        return "case \(propertyName) = \(customKeyValue)"
+      } else {
+        return "case \(propertyName)"
+      }
+    })
+
+    let codingKeys: DeclSyntax = """
+      enum CodingKeys: String, CodingKey {
+        \(raw: cases.joined(separator: "\n"))
+      }
+      """
+
+    return [codingKeys]
+  }
+}
+
+public struct CodableKey: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    // Does nothing, used only to decorate members with data
+    return []
+  }
+}

--- a/Tests/MacroTestingTests/MacroExamples/Diagnostics.swift
+++ b/Tests/MacroTestingTests/MacroExamples/Diagnostics.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+
+struct SimpleDiagnosticMessage: DiagnosticMessage, Error {
+  let message: String
+  let diagnosticID: MessageID
+  let severity: DiagnosticSeverity
+}
+
+extension SimpleDiagnosticMessage: FixItMessage {
+  var fixItID: MessageID { diagnosticID }
+}
+
+enum CustomError: Error, CustomStringConvertible {
+  case message(String)
+
+  var description: String {
+    switch self {
+    case .message(let text):
+      return text
+    }
+  }
+}

--- a/Tests/MacroTestingTests/MacroExamples/DiagnosticsAndFixitsEmitterMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/DiagnosticsAndFixitsEmitterMacro.swift
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+/// Emits two diagnostics, the first of which is a warning and has two fix-its, and
+/// the second is a note and has no fix-its.
+public enum DiagnosticsAndFixitsEmitterMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let firstFixIt = FixIt(
+      message: SimpleDiagnosticMessage(
+        message: "This is the first fix-it.",
+        diagnosticID: MessageID(domain: "domain", id: "fixit1"),
+        severity: .error),
+      changes: [
+        .replace(oldNode: Syntax(node), newNode: Syntax(node))  // no-op
+      ])
+    let secondFixIt = FixIt(
+      message: SimpleDiagnosticMessage(
+        message: "This is the second fix-it.",
+        diagnosticID: MessageID(domain: "domain", id: "fixit2"),
+        severity: .error),
+      changes: [
+        .replace(oldNode: Syntax(node), newNode: Syntax(node))  // no-op
+      ])
+
+    context.diagnose(
+      Diagnostic(
+        node: node.attributeName,
+        message: SimpleDiagnosticMessage(
+          message: "This is the first diagnostic.",
+          diagnosticID: MessageID(domain: "domain", id: "diagnostic2"),
+          severity: .warning),
+        fixIts: [firstFixIt, secondFixIt]))
+    context.diagnose(
+      Diagnostic(
+        node: node.attributeName,
+        message: SimpleDiagnosticMessage(
+          message: "This is the second diagnostic, it's a note.",
+          diagnosticID: MessageID(domain: "domain", id: "diagnostic2"),
+          severity: .note)))
+
+    return []
+  }
+}

--- a/Tests/MacroTestingTests/MacroExamples/DictionaryIndirectionMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/DictionaryIndirectionMacro.swift
@@ -1,0 +1,95 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct DictionaryStorageMacro {}
+
+extension DictionaryStorageMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let storage: DeclSyntax = "var _storage: [String: Any] = [:]"
+    return [
+      storage.with(\.leadingTrivia, [.newlines(1), .spaces(2)])
+    ]
+  }
+}
+
+extension DictionaryStorageMacro: MemberAttributeMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingAttributesFor member: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [AttributeSyntax] {
+    guard let property = member.as(VariableDeclSyntax.self),
+      property.isStoredProperty
+    else {
+      return []
+    }
+
+    return [
+      AttributeSyntax(
+        attributeName: IdentifierTypeSyntax(
+          name: .identifier("DictionaryStorageProperty")
+        )
+      )
+      .with(\.leadingTrivia, [.newlines(1), .spaces(2)])
+    ]
+  }
+}
+
+public struct DictionaryStoragePropertyMacro: AccessorMacro {
+  public static func expansion<
+    Context: MacroExpansionContext,
+    Declaration: DeclSyntaxProtocol
+  >(
+    of node: AttributeSyntax,
+    providingAccessorsOf declaration: Declaration,
+    in context: Context
+  ) throws -> [AccessorDeclSyntax] {
+    guard let varDecl = declaration.as(VariableDeclSyntax.self),
+      let binding = varDecl.bindings.first,
+      let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier,
+      binding.accessorBlock == nil,
+      let type = binding.typeAnnotation?.type
+    else {
+      return []
+    }
+
+    // Ignore the "_storage" variable.
+    if identifier.text == "_storage" {
+      return []
+    }
+
+    guard let defaultValue = binding.initializer?.value else {
+      throw CustomError.message("stored property must have an initializer")
+    }
+
+    return [
+      """
+      get {
+        _storage[\(literal: identifier.text), default: \(defaultValue)] as! \(type)
+      }
+      """,
+      """
+      set {
+        _storage[\(literal: identifier.text)] = newValue
+      }
+      """,
+    ]
+  }
+}

--- a/Tests/MacroTestingTests/MacroExamples/EquatableExtensionMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/EquatableExtensionMacro.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public enum EquatableExtensionMacro: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    let equatableExtension = try ExtensionDeclSyntax("extension \(type.trimmed): Equatable {}")
+
+    return [equatableExtension]
+  }
+}

--- a/Tests/MacroTestingTests/MacroExamples/FontLiteralMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/FontLiteralMacro.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Implementation of the `#fontLiteral` macro, which is similar in spirit
+/// to the built-in expressions `#colorLiteral`, `#imageLiteral`, etc., but in
+/// a small macro.
+public enum FontLiteralMacro: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> ExprSyntax {
+    let argList = replaceFirstLabel(
+      of: node.argumentList,
+      with: "fontLiteralName"
+    )
+    return ".init(\(argList))"
+  }
+}
+
+/// Replace the label of the first element in the tuple with the given
+/// new label.
+private func replaceFirstLabel(
+  of tuple: LabeledExprListSyntax,
+  with newLabel: String
+) -> LabeledExprListSyntax {
+  guard let firstElement = tuple.first else {
+    return tuple
+  }
+
+  var tuple = tuple
+  tuple[tuple.startIndex] =
+    firstElement
+    .with(\.label, .identifier(newLabel))
+    .with(\.colon, .colonToken())
+  return tuple
+}

--- a/Tests/MacroTestingTests/MacroExamples/FuncUniqueMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/FuncUniqueMacro.swift
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+/// Func With unique name.
+public enum FuncUniqueMacro: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let name = context.makeUniqueName("unique")
+    return [
+      """
+      class MyClass {
+        func \(name)() {}
+      }
+      """
+    ]
+  }
+}

--- a/Tests/MacroTestingTests/MacroExamples/MemberDeprecatedMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/MemberDeprecatedMacro.swift
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Add '@available(*, deprecated)' to members.
+public enum MemberDeprecatedMacro: MemberAttributeMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingAttributesFor member: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [AttributeSyntax] {
+    return ["@available(*, deprecated)"]
+  }
+}

--- a/Tests/MacroTestingTests/MacroExamples/MetaEnumMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/MetaEnumMacro.swift
@@ -1,0 +1,158 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct MetaEnumMacro {
+  let parentTypeName: TokenSyntax
+  let childCases: [EnumCaseElementSyntax]
+  let access: DeclModifierListSyntax.Element?
+  let parentParamName: TokenSyntax
+
+  init(
+    node: AttributeSyntax, declaration: some DeclGroupSyntax, context: some MacroExpansionContext
+  ) throws {
+    guard let enumDecl = declaration.as(EnumDeclSyntax.self) else {
+      throw DiagnosticsError(diagnostics: [
+        CaseMacroDiagnostic.notAnEnum(declaration).diagnose(at: Syntax(node))
+      ])
+    }
+
+    parentTypeName = enumDecl.name.with(\.trailingTrivia, [])
+
+    access = enumDecl.modifiers.first(where: \.isNeededAccessLevelModifier)
+
+    childCases = enumDecl.caseElements.map { parentCase in
+      parentCase.with(\.parameterClause, nil)
+    }
+
+    parentParamName = context.makeUniqueName("parent")
+  }
+
+  func makeMetaEnum() -> DeclSyntax {
+    // FIXME: Why does this need to be a string to make trailing trivia work properly?
+    let caseDecls =
+      childCases
+      .map { childCase in
+        "  case \(childCase.name)"
+      }
+      .joined(separator: "\n")
+
+    return """
+      \(access)enum Meta {
+      \(raw: caseDecls)
+      \(makeMetaInit())
+      }
+      """
+  }
+
+  func makeMetaInit() -> DeclSyntax {
+    // FIXME: Why does this need to be a string to make trailing trivia work properly?
+    let caseStatements =
+      childCases
+      .map { childCase in
+        """
+          case .\(childCase.name):
+            self = .\(childCase.name)
+        """
+      }
+      .joined(separator: "\n")
+
+    return """
+      \(access)init(_ \(parentParamName): \(parentTypeName)) {
+        switch \(parentParamName) {
+      \(raw: caseStatements)
+        }
+      }
+      """
+  }
+}
+
+extension MetaEnumMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let macro = try MetaEnumMacro(node: node, declaration: declaration, context: context)
+
+    return [macro.makeMetaEnum()]
+  }
+}
+
+extension EnumDeclSyntax {
+  var caseElements: [EnumCaseElementSyntax] {
+    memberBlock.members.flatMap { member in
+      guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) else {
+        return [EnumCaseElementSyntax]()
+      }
+
+      return Array(caseDecl.elements)
+    }
+  }
+}
+
+enum CaseMacroDiagnostic {
+  case notAnEnum(DeclGroupSyntax)
+}
+
+extension CaseMacroDiagnostic: DiagnosticMessage {
+  var message: String {
+    switch self {
+    case .notAnEnum(let decl):
+      return
+        "'@MetaEnum' can only be attached to an enum, not \(decl.descriptiveDeclKind(withArticle: true))"
+    }
+  }
+
+  var diagnosticID: MessageID {
+    switch self {
+    case .notAnEnum:
+      return MessageID(domain: "MetaEnumDiagnostic", id: "notAnEnum")
+    }
+  }
+
+  var severity: DiagnosticSeverity {
+    switch self {
+    case .notAnEnum:
+      return .error
+    }
+  }
+
+  func diagnose(at node: Syntax) -> Diagnostic {
+    Diagnostic(node: node, message: self)
+  }
+}
+
+extension DeclGroupSyntax {
+  func descriptiveDeclKind(withArticle article: Bool = false) -> String {
+    switch self {
+    case is ActorDeclSyntax:
+      return article ? "an actor" : "actor"
+    case is ClassDeclSyntax:
+      return article ? "a class" : "class"
+    case is ExtensionDeclSyntax:
+      return article ? "an extension" : "extension"
+    case is ProtocolDeclSyntax:
+      return article ? "a protocol" : "protocol"
+    case is StructDeclSyntax:
+      return article ? "a struct" : "struct"
+    case is EnumDeclSyntax:
+      return article ? "an enum" : "enum"
+    default:
+      fatalError("Unknown DeclGroupSyntax")
+    }
+  }
+}

--- a/Tests/MacroTestingTests/MacroExamples/NewTypeMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/NewTypeMacro.swift
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public enum NewTypeMacro {}
+
+extension NewTypeMacro: MemberMacro {
+  public static func expansion<Declaration, Context>(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: Declaration,
+    in context: Context
+  ) throws -> [DeclSyntax] where Declaration: DeclGroupSyntax, Context: MacroExpansionContext {
+    do {
+      guard
+        case .argumentList(let arguments) = node.arguments,
+        arguments.count == 1,
+        let memberAccessExn = arguments.first?
+          .expression.as(MemberAccessExprSyntax.self),
+        let rawType = memberAccessExn.base?.as(DeclReferenceExprSyntax.self)
+      else {
+        throw CustomError.message(
+          #"@NewType requires the raw type as an argument, in the form "RawType.self"."#)
+      }
+
+      guard let declaration = declaration.as(StructDeclSyntax.self) else {
+        throw CustomError.message("@NewType can only be applied to a struct declarations.")
+      }
+
+      let access = declaration.modifiers.first(where: \.isNeededAccessLevelModifier)
+
+      return [
+        "\(access)typealias RawValue = \(rawType)",
+        "\(access)var rawValue: RawValue",
+        "\(access)init(_ rawValue: RawValue) { self.rawValue = rawValue }",
+      ]
+    } catch {
+      print("--------------- throwing \(error)")
+      throw error
+    }
+  }
+}
+
+extension DeclModifierSyntax {
+  var isNeededAccessLevelModifier: Bool {
+    switch self.name.tokenKind {
+    case .keyword(.public): return true
+    default: return false
+    }
+  }
+}
+
+extension SyntaxStringInterpolation {
+  // It would be nice for SwiftSyntaxBuilder to provide this out-of-the-box.
+  mutating func appendInterpolation<Node: SyntaxProtocol>(_ node: Node?) {
+    if let node {
+      appendInterpolation(node)
+    }
+  }
+}

--- a/Tests/MacroTestingTests/MacroExamples/OptionSetMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/OptionSetMacro.swift
@@ -1,0 +1,208 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+enum OptionSetMacroDiagnostic {
+  case requiresStruct
+  case requiresStringLiteral(String)
+  case requiresOptionsEnum(String)
+  case requiresOptionsEnumRawType
+}
+
+extension OptionSetMacroDiagnostic: DiagnosticMessage {
+  func diagnose(at node: some SyntaxProtocol) -> Diagnostic {
+    Diagnostic(node: Syntax(node), message: self)
+  }
+
+  var message: String {
+    switch self {
+    case .requiresStruct:
+      return "'OptionSet' macro can only be applied to a struct"
+
+    case .requiresStringLiteral(let name):
+      return "'OptionSet' macro argument \(name) must be a string literal"
+
+    case .requiresOptionsEnum(let name):
+      return "'OptionSet' macro requires nested options enum '\(name)'"
+
+    case .requiresOptionsEnumRawType:
+      return "'OptionSet' macro requires a raw type"
+    }
+  }
+
+  var severity: DiagnosticSeverity { .error }
+
+  var diagnosticID: MessageID {
+    MessageID(domain: "Swift", id: "OptionSet.\(self)")
+  }
+}
+
+/// The label used for the OptionSet macro argument that provides the name of
+/// the nested options enum.
+private let optionsEnumNameArgumentLabel = "optionsName"
+
+/// The default name used for the nested "Options" enum. This should
+/// eventually be overridable.
+private let defaultOptionsEnumName = "Options"
+
+extension LabeledExprListSyntax {
+  /// Retrieve the first element with the given label.
+  func first(labeled name: String) -> Element? {
+    return first { element in
+      if let label = element.label, label.text == name {
+        return true
+      }
+
+      return false
+    }
+  }
+}
+
+public struct OptionSetMacro {
+  /// Decodes the arguments to the macro expansion.
+  ///
+  /// - Returns: the important arguments used by the various roles of this
+  /// macro inhabits, or nil if an error occurred.
+  static func decodeExpansion(
+    of attribute: AttributeSyntax,
+    attachedTo decl: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) -> (StructDeclSyntax, EnumDeclSyntax, TypeSyntax)? {
+    // Determine the name of the options enum.
+    let optionsEnumName: String
+    if case let .argumentList(arguments) = attribute.arguments,
+      let optionEnumNameArg = arguments.first(labeled: optionsEnumNameArgumentLabel)
+    {
+      // We have a options name; make sure it is a string literal.
+      guard let stringLiteral = optionEnumNameArg.expression.as(StringLiteralExprSyntax.self),
+        stringLiteral.segments.count == 1,
+        case let .stringSegment(optionsEnumNameString)? = stringLiteral.segments.first
+      else {
+        context.diagnose(
+          OptionSetMacroDiagnostic.requiresStringLiteral(optionsEnumNameArgumentLabel).diagnose(
+            at: optionEnumNameArg.expression))
+        return nil
+      }
+
+      optionsEnumName = optionsEnumNameString.content.text
+    } else {
+      optionsEnumName = defaultOptionsEnumName
+    }
+
+    // Only apply to structs.
+    guard let structDecl = decl.as(StructDeclSyntax.self) else {
+      context.diagnose(OptionSetMacroDiagnostic.requiresStruct.diagnose(at: decl))
+      return nil
+    }
+
+    // Find the option enum within the struct.
+    guard
+      let optionsEnum = decl.memberBlock.members.compactMap({ member in
+        if let enumDecl = member.decl.as(EnumDeclSyntax.self),
+          enumDecl.name.text == optionsEnumName
+        {
+          return enumDecl
+        }
+
+        return nil
+      }).first
+    else {
+      context.diagnose(
+        OptionSetMacroDiagnostic.requiresOptionsEnum(optionsEnumName).diagnose(at: decl))
+      return nil
+    }
+
+    // Retrieve the raw type from the attribute.
+    guard
+      let genericArgs = attribute.attributeName.as(IdentifierTypeSyntax.self)?
+        .genericArgumentClause,
+      let rawType = genericArgs.arguments.first?.argument
+    else {
+      context.diagnose(OptionSetMacroDiagnostic.requiresOptionsEnumRawType.diagnose(at: attribute))
+      return nil
+    }
+
+    return (structDecl, optionsEnum, rawType)
+  }
+}
+
+extension OptionSetMacro: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    // Decode the expansion arguments.
+    guard let (structDecl, _, _) = decodeExpansion(of: node, attachedTo: declaration, in: context)
+    else {
+      return []
+    }
+
+    // If there is an explicit conformance to OptionSet already, don't add one.
+    if let inheritedTypes = structDecl.inheritanceClause?.inheritedTypes,
+      inheritedTypes.contains(
+        where: { inherited in inherited.type.trimmedDescription == "OptionSet" }
+      )
+    {
+      return []
+    }
+
+    return [try ExtensionDeclSyntax("extension \(type): OptionSet {}")]
+  }
+}
+
+extension OptionSetMacro: MemberMacro {
+  public static func expansion(
+    of attribute: AttributeSyntax,
+    providingMembersOf decl: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    // Decode the expansion arguments.
+    guard
+      let (_, optionsEnum, rawType) = decodeExpansion(of: attribute, attachedTo: decl, in: context)
+    else {
+      return []
+    }
+
+    // Find all of the case elements.
+    let caseElements = optionsEnum.memberBlock.members.flatMap { member in
+      guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) else {
+        return [EnumCaseElementSyntax]()
+      }
+
+      return Array(caseDecl.elements)
+    }
+
+    // Dig out the access control keyword we need.
+    let access = decl.modifiers.first(where: \.isNeededAccessLevelModifier)
+
+    let staticVars = caseElements.map { (element) -> DeclSyntax in
+      """
+      \(access) static let \(element.name): Self =
+        Self(rawValue: 1 << \(optionsEnum.name).\(element.name).rawValue)
+      """
+    }
+
+    return [
+      "\(access)typealias RawValue = \(rawType)",
+      "\(access)var rawValue: RawValue",
+      "\(access)init() { self.rawValue = 0 }",
+      "\(access)init(rawValue: RawValue) { self.rawValue = rawValue }",
+    ] + staticVars
+  }
+}

--- a/Tests/MacroTestingTests/MacroExamples/PeerValueWithSuffixMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/PeerValueWithSuffixMacro.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Peer 'var' with the name suffixed with '_peer'.
+public enum PeerValueWithSuffixNameMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard let identified = declaration.asProtocol(NamedDeclSyntax.self) else {
+      return []
+    }
+    return ["var \(raw: identified.name.text)_peer: Int { 1 }"]
+  }
+}

--- a/Tests/MacroTestingTests/MacroExamples/StringifyMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/StringifyMacro.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+/// Implementation of the `stringify` macro, which takes an expression
+/// of any type and produces a tuple containing the value of that expression
+/// and the source code that produced the value. For example
+///
+///     #stringify(x + y)
+///
+///  will expand to
+///
+///     (x + y, "x + y")
+public enum StringifyMacro: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    guard let argument = node.argumentList.first?.expression else {
+      fatalError("compiler bug: the macro does not have any arguments")
+    }
+
+    return "(\(argument), \(literal: argument.description))"
+  }
+}

--- a/Tests/MacroTestingTests/MacroExamples/URLMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/URLMacro.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Creates a non-optional URL from a static string. The string is checked to
+/// be valid during compile time.
+public enum URLMacro: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> ExprSyntax {
+    guard let argument = node.argumentList.first?.expression,
+      let segments = argument.as(StringLiteralExprSyntax.self)?.segments,
+      segments.count == 1,
+      case .stringSegment(let literalSegment)? = segments.first
+    else {
+      throw CustomError.message("#URL requires a static string literal")
+    }
+
+    guard let _ = URL(string: literalSegment.content.text) else {
+      throw CustomError.message("malformed url: \(argument)")
+    }
+
+    return "URL(string: \(argument))!"
+  }
+}

--- a/Tests/MacroTestingTests/MacroExamples/WarningMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/WarningMacro.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Implementation of the `myWarning` macro, which mimics the behavior of the
+/// built-in `#warning`.
+public enum WarningMacro: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> ExprSyntax {
+    guard let firstElement = node.argumentList.first,
+      let stringLiteral = firstElement.expression
+        .as(StringLiteralExprSyntax.self),
+      stringLiteral.segments.count == 1,
+      case let .stringSegment(messageString)? = stringLiteral.segments.first
+    else {
+      throw CustomError.message("#myWarning macro requires a string literal")
+    }
+
+    context.diagnose(
+      Diagnostic(
+        node: Syntax(node),
+        message: SimpleDiagnosticMessage(
+          message: messageString.content.description,
+          diagnosticID: MessageID(domain: "test123", id: "error"),
+          severity: .warning
+        )
+      )
+    )
+
+    return "()"
+  }
+}

--- a/Tests/MacroTestingTests/MacroExamples/WrapStoredPropertiesMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/WrapStoredPropertiesMacro.swift
@@ -1,0 +1,111 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+/// Implementation of the `wrapStoredProperties` macro, which can be
+/// used to apply an attribute to all of the stored properties of a type.
+///
+/// This macro demonstrates member-attribute macros, which allow an attribute
+/// written on a type or extension to apply attributes to the members
+/// declared within that type or extension.
+public struct WrapStoredPropertiesMacro: MemberAttributeMacro {
+  public static func expansion<
+    Declaration: DeclGroupSyntax,
+    Context: MacroExpansionContext
+  >(
+    of node: AttributeSyntax,
+    attachedTo decl: Declaration,
+    providingAttributesFor member: some DeclSyntaxProtocol,
+    in context: Context
+  ) throws -> [AttributeSyntax] {
+    guard let property = member.as(VariableDeclSyntax.self),
+      property.isStoredProperty
+    else {
+      return []
+    }
+
+    guard case let .argumentList(arguments) = node.arguments,
+      let firstElement = arguments.first,
+      let stringLiteral = firstElement.expression
+        .as(StringLiteralExprSyntax.self),
+      stringLiteral.segments.count == 1,
+      case let .stringSegment(wrapperName)? = stringLiteral.segments.first
+    else {
+      throw CustomError.message(
+        "macro requires a string literal containing the name of an attribute")
+    }
+
+    return [
+      AttributeSyntax(
+        attributeName: IdentifierTypeSyntax(
+          name: .identifier(wrapperName.content.text)
+        )
+      )
+      .with(\.leadingTrivia, [.newlines(1), .spaces(2)])
+    ]
+  }
+}
+
+extension VariableDeclSyntax {
+  /// Determine whether this variable has the syntax of a stored property.
+  ///
+  /// This syntactic check cannot account for semantic adjustments due to,
+  /// e.g., accessor macros or property wrappers.
+  var isStoredProperty: Bool {
+    if bindings.count != 1 {
+      return false
+    }
+
+    let binding = bindings.first!
+    switch binding.accessorBlock?.accessors {
+    case .none:
+      return true
+
+    case .accessors(let accessors):
+      for accessor in accessors {
+        switch accessor.accessorSpecifier.tokenKind {
+        case .keyword(.willSet), .keyword(.didSet):
+          // Observers can occur on a stored property.
+          break
+
+        default:
+          // Other accessors make it a computed property.
+          return false
+        }
+      }
+
+      return true
+
+    case .getter:
+      return false
+    }
+  }
+}
+
+extension DeclGroupSyntax {
+  /// Enumerate the stored properties that syntactically occur in this
+  /// declaration.
+  func storedProperties() -> [VariableDeclSyntax] {
+    return memberBlock.members.compactMap { member in
+      guard let variable = member.decl.as(VariableDeclSyntax.self),
+        variable.isStoredProperty
+      else {
+        return nil
+      }
+
+      return variable
+    }
+  }
+}

--- a/Tests/MacroTestingTests/MacroNameTests.swift
+++ b/Tests/MacroTestingTests/MacroNameTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+
+@testable import MacroTesting
+
+final class MacroNameTests: BaseTestCase {
+  func testBasics() {
+    XCTAssertEqual(
+      macroName(className: "AddAsyncHandler", isExpression: false),
+      "AddAsyncHandler"
+    )
+    XCTAssertEqual(
+      macroName(className: "AddAsyncHandlerMacro", isExpression: false),
+      "AddAsyncHandler"
+    )
+    XCTAssertEqual(
+      macroName(className: "URL", isExpression: false),
+      "URL"
+    )
+    XCTAssertEqual(
+      macroName(className: "URLMacro", isExpression: false),
+      "URL"
+    )
+    XCTAssertEqual(
+      macroName(className: "URL", isExpression: true),
+      "url"
+    )
+    XCTAssertEqual(
+      macroName(className: "URLMacro", isExpression: true),
+      "url"
+    )
+    XCTAssertEqual(
+      macroName(className: "URLComponents", isExpression: true),
+      "urlComponents"
+    )
+    XCTAssertEqual(
+      macroName(className: "URLComponentsMacro", isExpression: true),
+      "urlComponents"
+    )
+    XCTAssertEqual(
+      macroName(className: "FontLiteral", isExpression: true),
+      "fontLiteral"
+    )
+    XCTAssertEqual(
+      macroName(className: "FontLiteralMacro", isExpression: true),
+      "fontLiteral"
+    )
+  }
+}

--- a/Tests/MacroTestingTests/MemberDeprecatedMacroTests.swift
+++ b/Tests/MacroTestingTests/MemberDeprecatedMacroTests.swift
@@ -1,0 +1,42 @@
+import MacroTesting
+import XCTest
+
+final class MemberDepreacatedMacroTests: XCTestCase {
+  override func invokeTest() {
+    withMacroTesting(macros: ["memberDeprecated": MemberDeprecatedMacro.self]) {
+      super.invokeTest()
+    }
+  }
+
+  func testExpansionMarksMembersAsDeprecated() {
+    assertMacro {
+      """
+      @memberDeprecated
+      public struct SomeStruct {
+        typealias MacroName = String
+
+        public var oldProperty: Int = 420
+
+        func oldMethod() {
+          print("This is an old method.")
+        }
+      }
+      """
+    } expansion: {
+      """
+      public struct SomeStruct {
+        @available(*, deprecated)
+        typealias MacroName = String
+        @available(*, deprecated)
+
+        public var oldProperty: Int = 420
+        @available(*, deprecated)
+
+        func oldMethod() {
+          print("This is an old method.")
+        }
+      }
+      """
+    }
+  }
+}

--- a/Tests/MacroTestingTests/MetaEnumMacroTests.swift
+++ b/Tests/MacroTestingTests/MetaEnumMacroTests.swift
@@ -1,0 +1,109 @@
+import MacroTesting
+import XCTest
+
+final class MetaEnumMacroTests: BaseTestCase {
+  override func invokeTest() {
+    withMacroTesting(macros: [MetaEnumMacro.self]) {
+      super.invokeTest()
+    }
+  }
+
+  func testExpansionAddsNestedMetaEnum() {
+    assertMacro {
+      """
+      @MetaEnum enum Cell {
+        case integer(Int)
+        case text(String)
+        case boolean(Bool)
+        case null
+      }
+      """
+    } expansion: {
+      """
+      enum Cell {
+        case integer(Int)
+        case text(String)
+        case boolean(Bool)
+        case null
+
+        enum Meta {
+          case integer
+          case text
+          case boolean
+          case null
+          init(_ __macro_local_6parentfMu_: Cell) {
+            switch __macro_local_6parentfMu_ {
+            case .integer:
+              self = .integer
+            case .text:
+              self = .text
+            case .boolean:
+              self = .boolean
+            case .null:
+              self = .null
+            }
+          }
+        }
+      }
+      """
+    }
+  }
+
+  func testExpansionAddsPublicNestedMetaEnum() {
+    assertMacro {
+      """
+      @MetaEnum public enum Cell {
+        case integer(Int)
+        case text(String)
+        case boolean(Bool)
+      }
+      """
+    } expansion: {
+      """
+      public enum Cell {
+        case integer(Int)
+        case text(String)
+        case boolean(Bool)
+
+        public enum Meta {
+          case integer
+          case text
+          case boolean
+          public init(_ __macro_local_6parentfMu_: Cell) {
+            switch __macro_local_6parentfMu_ {
+            case .integer:
+              self = .integer
+            case .text:
+              self = .text
+            case .boolean:
+              self = .boolean
+            }
+          }
+        }
+      }
+      """
+    }
+  }
+
+  func testExpansionOnStructEmitsError() {
+    assertMacro {
+      """
+      @MetaEnum struct Cell {
+        let integer: Int
+        let text: String
+        let boolean: Bool
+      }
+      """
+    } diagnostics: {
+      """
+      @MetaEnum struct Cell {
+      ┬────────
+      ╰─ 🛑 '@MetaEnum' can only be attached to an enum, not a struct
+        let integer: Int
+        let text: String
+        let boolean: Bool
+      }
+      """
+    }
+  }
+}

--- a/Tests/MacroTestingTests/NewTypeMacroTests.swift
+++ b/Tests/MacroTestingTests/NewTypeMacroTests.swift
@@ -1,0 +1,92 @@
+import MacroTesting
+import XCTest
+
+final class NewTypeMacroTests: BaseTestCase {
+  override func invokeTest() {
+    withMacroTesting(macros: [NewTypeMacro.self]) {
+      super.invokeTest()
+    }
+  }
+
+  func testExpansionAddsStringRawType() {
+    assertMacro {
+      """
+      @NewType(String.self)
+      struct Username {
+      }
+      """
+    } expansion: {
+      """
+      struct Username {
+
+          typealias RawValue = String
+
+          var rawValue: RawValue
+
+          init(_ rawValue: RawValue) {
+              self.rawValue = rawValue
+          }
+      }
+      """
+    }
+  }
+
+  func testExpansionWithPublicAddsPublicStringRawType() {
+    assertMacro {
+      """
+      @NewType(String.self)
+      public struct MyString {
+      }
+      """
+    } expansion: {
+      """
+      public struct MyString {
+
+          public typealias RawValue = String
+
+          public var rawValue: RawValue
+
+          public init(_ rawValue: RawValue) {
+              self.rawValue = rawValue
+          }
+      }
+      """
+    }
+  }
+
+  func testExpansionOnClassEmitsError() {
+    assertMacro {
+      """
+      @NewType(Int.self)
+      class NotAUsername {
+      }
+      """
+    } diagnostics: {
+      """
+      @NewType(Int.self)
+      ┬─────────────────
+      ╰─ 🛑 @NewType can only be applied to a struct declarations.
+      class NotAUsername {
+      }
+      """
+    }
+  }
+
+  func testExpansionWithMissingRawTypeEmitsError() {
+    assertMacro {
+      """
+      @NewType
+      struct NoRawType {
+      }
+      """
+    } diagnostics: {
+      """
+      @NewType
+      ┬───────
+      ╰─ 🛑 @NewType requires the raw type as an argument, in the form "RawType.self".
+      struct NoRawType {
+      }
+      """
+    }
+  }
+}

--- a/Tests/MacroTestingTests/OptionSetMacroTests.swift
+++ b/Tests/MacroTestingTests/OptionSetMacroTests.swift
@@ -1,0 +1,178 @@
+import MacroTesting
+import XCTest
+
+final class OptionSetMacroTests: BaseTestCase {
+  override func invokeTest() {
+    withMacroTesting(macros: ["MyOptionSet": OptionSetMacro.self]) {
+      super.invokeTest()
+    }
+  }
+
+  func testExpansionOnStructWithNestedEnumAndStatics() {
+    assertMacro {
+      """
+      @MyOptionSet<UInt8>
+      struct ShippingOptions {
+        private enum Options: Int {
+          case nextDay
+          case secondDay
+          case priority
+          case standard
+        }
+
+        static let express: ShippingOptions = [.nextDay, .secondDay]
+        static let all: ShippingOptions = [.express, .priority, .standard]
+      }
+      """
+    } expansion: {
+      """
+      struct ShippingOptions {
+        private enum Options: Int {
+          case nextDay
+          case secondDay
+          case priority
+          case standard
+        }
+
+        static let express: ShippingOptions = [.nextDay, .secondDay]
+        static let all: ShippingOptions = [.express, .priority, .standard]
+
+        typealias RawValue = UInt8
+
+        var rawValue: RawValue
+
+        init() {
+          self.rawValue = 0
+        }
+
+        init(rawValue: RawValue) {
+          self.rawValue = rawValue
+        }
+
+        static let nextDay: Self =
+          Self (rawValue: 1 << Options.nextDay.rawValue)
+
+        static let secondDay: Self =
+          Self (rawValue: 1 << Options.secondDay.rawValue)
+
+        static let priority: Self =
+          Self (rawValue: 1 << Options.priority.rawValue)
+
+        static let standard: Self =
+          Self (rawValue: 1 << Options.standard.rawValue)
+      }
+
+      extension ShippingOptions: OptionSet {
+      }
+      """
+    }
+  }
+
+  func testExpansionOnPublicStructWithExplicitOptionSetConformance() {
+    assertMacro {
+      """
+      @MyOptionSet<UInt8>
+      public struct ShippingOptions: OptionSet {
+        private enum Options: Int {
+          case nextDay
+          case standard
+        }
+      }
+      """
+    } expansion: {
+      """
+      public struct ShippingOptions: OptionSet {
+        private enum Options: Int {
+          case nextDay
+          case standard
+        }
+
+        public typealias RawValue = UInt8
+
+        public var rawValue: RawValue
+
+        public init() {
+          self.rawValue = 0
+        }
+
+        public init(rawValue: RawValue) {
+          self.rawValue = rawValue
+        }
+
+        public  static let nextDay: Self =
+          Self (rawValue: 1 << Options.nextDay.rawValue)
+
+        public  static let standard: Self =
+          Self (rawValue: 1 << Options.standard.rawValue)
+      }
+      """
+    }
+  }
+
+  func testExpansionFailsOnEnumType() {
+    assertMacro {
+      """
+      @MyOptionSet<UInt8>
+      enum Animal {
+        case dog
+      }
+      """
+    } diagnostics: {
+      """
+      @MyOptionSet<UInt8>
+      ├─ 🛑 'OptionSet' macro can only be applied to a struct
+      ╰─ 🛑 'OptionSet' macro can only be applied to a struct
+      enum Animal {
+        case dog
+      }
+      """
+    }
+  }
+
+  func testExpansionFailsWithoutNestedOptionsEnum() {
+    assertMacro {
+      """
+      @MyOptionSet<UInt8>
+      struct ShippingOptions {
+        static let express: ShippingOptions = [.nextDay, .secondDay]
+        static let all: ShippingOptions = [.express, .priority, .standard]
+      }
+      """
+    } diagnostics: {
+      """
+      @MyOptionSet<UInt8>
+      ├─ 🛑 'OptionSet' macro requires nested options enum 'Options'
+      ╰─ 🛑 'OptionSet' macro requires nested options enum 'Options'
+      struct ShippingOptions {
+        static let express: ShippingOptions = [.nextDay, .secondDay]
+        static let all: ShippingOptions = [.express, .priority, .standard]
+      }
+      """
+    }
+  }
+
+  func testExpansionFailsWithoutSpecifiedRawType() {
+    assertMacro {
+      """
+      @MyOptionSet
+      struct ShippingOptions {
+        private enum Options: Int {
+          case nextDay
+        }
+      }
+      """
+    } diagnostics: {
+      """
+      @MyOptionSet
+      ┬───────────
+      ├─ 🛑 'OptionSet' macro requires a raw type
+      ╰─ 🛑 'OptionSet' macro requires a raw type
+      struct ShippingOptions {
+        private enum Options: Int {
+          case nextDay
+        }
+      }
+      """
+    }
+  }
+}

--- a/Tests/MacroTestingTests/PeerValueWithSuffixMacroTests.swift
+++ b/Tests/MacroTestingTests/PeerValueWithSuffixMacroTests.swift
@@ -1,0 +1,57 @@
+import MacroTesting
+import XCTest
+
+final class PeerValueWithSuffixNameMacroTests: XCTestCase {
+  override func invokeTest() {
+    withMacroTesting(macros: [PeerValueWithSuffixNameMacro.self]) {
+      super.invokeTest()
+    }
+  }
+
+  func testExpansionAddsPeerValueToPrivateActor() {
+    assertMacro {
+      """
+      @PeerValueWithSuffixName
+      private actor Counter {
+        var value = 0
+      }
+      """
+    } expansion: {
+      """
+      private actor Counter {
+        var value = 0
+      }
+
+      var Counter_peer: Int {
+        1
+      }
+      """
+    }
+  }
+
+  func testExpansionAddsPeerValueToFunction() {
+    assertMacro {
+      """
+      @PeerValueWithSuffixName
+      func someFunction() {}
+      """
+    } expansion: {
+      """
+      func someFunction() {}
+
+      var someFunction_peer: Int {
+          1
+      }
+      """
+    }
+  }
+
+  func testExpansionIgnoresVariables() {
+    assertMacro {
+      """
+      @PeerValueWithSuffixName
+      var someVariable: Int
+      """
+    }
+  }
+}

--- a/Tests/MacroTestingTests/StringifyMacroTests.swift
+++ b/Tests/MacroTestingTests/StringifyMacroTests.swift
@@ -1,0 +1,34 @@
+import MacroTesting
+import XCTest
+
+final class StringifyMacroTests: BaseTestCase {
+  override func invokeTest() {
+    withMacroTesting(macros: [StringifyMacro.self]) {
+      super.invokeTest()
+    }
+  }
+
+  func testExpansionWithBasicArithmeticExpression() {
+    assertMacro {
+      """
+      let a = #stringify(x + y)
+      """
+    } expansion: {
+      """
+      let a = (x + y, "x + y")
+      """
+    }
+  }
+
+  func testExpansionWithStringInterpolation() {
+    assertMacro {
+      #"""
+      let b = #stringify("Hello, \(name)")
+      """#
+    } expansion: {
+      #"""
+      let b = ("Hello, \(name)", #""Hello, \(name)""#)
+      """#
+    }
+  }
+}

--- a/Tests/MacroTestingTests/URLMacroTests.swift
+++ b/Tests/MacroTestingTests/URLMacroTests.swift
@@ -1,0 +1,50 @@
+import MacroTesting
+import XCTest
+
+final class URLMacroTests: BaseTestCase {
+  override func invokeTest() {
+    withMacroTesting(macros: ["URL": URLMacro.self]) {
+      super.invokeTest()
+    }
+  }
+
+  func testExpansionWithMalformedURLEmitsError() {
+    assertMacro {
+      """
+      let invalid = #URL("https://not a url.com")
+      """
+    } diagnostics: {
+      """
+      let invalid = #URL("https://not a url.com")
+                    ┬────────────────────────────
+                    ╰─ 🛑 malformed url: "https://not a url.com"
+      """
+    }
+  }
+
+  func testExpansionWithStringInterpolationEmitsError() {
+    assertMacro {
+      #"""
+      #URL("https://\(domain)/api/path")
+      """#
+    } diagnostics: {
+      #"""
+      #URL("https://\(domain)/api/path")
+      ┬─────────────────────────────────
+      ╰─ 🛑 #URL requires a static string literal
+      """#
+    }
+  }
+
+  func testExpansionWithValidURL() {
+    assertMacro {
+      """
+      let valid = #URL("https://swift.org/")
+      """
+    } expansion: {
+      """
+      let valid = URL(string: "https://swift.org/")!
+      """
+    }
+  }
+}

--- a/Tests/MacroTestingTests/WarningMacroTests.swift
+++ b/Tests/MacroTestingTests/WarningMacroTests.swift
@@ -1,0 +1,56 @@
+import MacroTesting
+import XCTest
+
+final class WarningMacroTests: BaseTestCase {
+  override func invokeTest() {
+    withMacroTesting(macros: ["myWarning": WarningMacro.self]) {
+      super.invokeTest()
+    }
+  }
+
+  func testExpansionWithValidStringLiteralEmitsWarning() {
+    assertMacro {
+      """
+      #myWarning("This is a warning")
+      """
+    } expansion: {
+      """
+      ()
+      """
+    } diagnostics: {
+      """
+      #myWarning("This is a warning")
+      ┬──────────────────────────────
+      ╰─ ⚠️ This is a warning
+      """
+    }
+  }
+
+  func testExpansionWithInvalidExpressionEmitsError() {
+    assertMacro {
+      """
+      #myWarning(42)
+      """
+    } diagnostics: {
+      """
+      #myWarning(42)
+      ┬─────────────
+      ╰─ 🛑 #myWarning macro requires a string literal
+      """
+    }
+  }
+
+  func testExpansionWithStringInterpolationEmitsError() {
+    assertMacro {
+      #"""
+      #myWarning("Say hello \(number) times!")
+      """#
+    } diagnostics: {
+      #"""
+      #myWarning("Say hello \(number) times!")
+      ┬───────────────────────────────────────
+      ╰─ 🛑 #myWarning macro requires a string literal
+      """#
+    }
+  }
+}

--- a/Tests/MacroTestingTests/WrapStoredPropertiesMacroTests.swift
+++ b/Tests/MacroTestingTests/WrapStoredPropertiesMacroTests.swift
@@ -1,0 +1,80 @@
+import MacroTesting
+import XCTest
+
+final class WrapStoredPropertiesMacroTests: BaseTestCase {
+  override func invokeTest() {
+    withMacroTesting(macros: ["wrapStoredProperties": WrapStoredPropertiesMacro.self]) {
+      super.invokeTest()
+    }
+  }
+
+  func testExpansionAddsPublished() {
+    assertMacro {
+      """
+      @wrapStoredProperties("Published")
+      struct Test {
+        var value: Int
+      }
+      """
+    } expansion: {
+      """
+      struct Test {
+        @Published
+        var value: Int
+      }
+      """
+    }
+  }
+
+  func testExpansionAddsDeprecationAttribute() {
+    assertMacro {
+      """
+      @wrapStoredProperties(#"available(*, deprecated, message: "hands off my data")"#)
+      struct Test {
+        var value: Int
+      }
+      """
+    } expansion: {
+      """
+      struct Test {
+        @available(*, deprecated, message: "hands off my data")
+        var value: Int
+      }
+      """
+    }
+  }
+
+  func testExpansionIgnoresComputedProperty() {
+    assertMacro {
+      """
+      @wrapStoredProperties("Published")
+      struct Test {
+        var value: Int {
+          get { return 0 }
+          set {}
+        }
+      }
+      """
+    }
+  }
+
+  func testExpansionWithInvalidAttributeEmitsError() {
+    assertMacro {
+      """
+      @wrapStoredProperties(12)
+      struct Test {
+        var value: Int
+      }
+      """
+    } diagnostics: {
+      """
+      @wrapStoredProperties(12)
+      ┬────────────────────────
+      ╰─ 🛑 macro requires a string literal containing the name of an attribute
+      struct Test {
+        var value: Int
+      }
+      """
+    }
+  }
+}

--- a/Tests/MemberwiseInitTests/CustomInitDefaultTests.swift
+++ b/Tests/MemberwiseInitTests/CustomInitDefaultTests.swift
@@ -64,7 +64,6 @@ final class CustomInitDefaultTests: XCTestCase {
     }
   }
 
-  // FIXME: Exclusively applicable fix-its aren't testable: https://github.com/pointfreeco/swift-macro-testing/issues/14
   // TODO: For 1.0, strengthen by rejecting @Init on already initialized let (not just on '@Init(default:)')
   func testInitializedLet() {
     assertMacro {
@@ -72,6 +71,15 @@ final class CustomInitDefaultTests: XCTestCase {
       @MemberwiseInit
       struct S {
         @Init(default: 42) let number = 0
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        @Init(default: 42) let number = 0
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
@@ -87,30 +95,40 @@ final class CustomInitDefaultTests: XCTestCase {
       """
     } fixes: {
       """
+      @Init(default: 42) let number = 0
+            ┬──────────
+            ╰─ 🛑 @Init can't be applied to already initialized constant
+
+      ✏️ Remove '@Init(default: 42)'
       @MemberwiseInit
       struct S {
         let number = 0
       }
-      """
-    } expansion: {
-      """
-      struct S {
-        let number = 0
 
-        internal init() {
-        }
+      ✏️ Remove '= 0'
+      @MemberwiseInit
+      struct S {
+        @Init(default: 42) let number: Int
       }
       """
     }
   }
 
-  // FIXME: Exclusively applicable fix-its aren't testable: https://github.com/pointfreeco/swift-macro-testing/issues/14
   func testInitializedLetCustomLabel() {
     assertMacro {
       """
       @MemberwiseInit
       struct S {
         @Init(default: 42, label: "_") let number = 0
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        @Init(default: 42, label: "_") let number = 0
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
@@ -126,30 +144,40 @@ final class CustomInitDefaultTests: XCTestCase {
       """
     } fixes: {
       """
+      @Init(default: 42, label: "_") let number = 0
+            ┬───────────
+            ╰─ 🛑 @Init can't be applied to already initialized constant
+
+      ✏️ Remove '@Init(default: 42, label: "_")'
       @MemberwiseInit
       struct S {
         let number = 0
       }
-      """
-    } expansion: {
-      """
-      struct S {
-        let number = 0
 
-        internal init() {
-        }
+      ✏️ Remove '= 0'
+      @MemberwiseInit
+      struct S {
+        @Init(default: 42, label: "_") let number: Int
       }
       """
     }
   }
 
-  // FIXME: Exclusively applicable fix-its aren't testable: https://github.com/pointfreeco/swift-macro-testing/issues/14
   func testInitializedVar() {
     assertMacro {
       """
       @MemberwiseInit
       struct S {
         @Init(default: 42) var number = 0
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        @Init(default: 42) var number = 0
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
@@ -165,33 +193,40 @@ final class CustomInitDefaultTests: XCTestCase {
       """
     } fixes: {
       """
+      @Init(default: 42) var number = 0
+            ┬──────────
+            ╰─ 🛑 Custom 'default' can't be applied to already initialized variable
+
+      ✏️ Remove '@Init(default: 42)'
       @MemberwiseInit
       struct S {
         var number = 0
       }
-      """
-    } expansion: {
-      """
-      struct S {
-        var number = 0
 
-        internal init(
-          number: Int = 0
-        ) {
-          self.number = number
-        }
+      ✏️ Remove '= 0'
+      @MemberwiseInit
+      struct S {
+        @Init(default: 42) var number: Int
       }
       """
     }
   }
 
-  // FIXME: Exclusively applicable fix-its aren't testable: https://github.com/pointfreeco/swift-macro-testing/issues/14
   func testAttributedInitializedLet() {
     assertMacro {
       """
       @MemberwiseInit
       struct S {
         @Binding @Init(default: 42) let number = 0
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        @Binding @Init(default: 42) let number = 0
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
@@ -207,30 +242,40 @@ final class CustomInitDefaultTests: XCTestCase {
       """
     } fixes: {
       """
+      @Binding @Init(default: 42) let number = 0
+                     ┬──────────
+                     ╰─ 🛑 @Init can't be applied to already initialized constant
+
+      ✏️ Remove '@Init(default: 42)'
       @MemberwiseInit
       struct S {
         @Binding let number = 0
       }
-      """
-    } expansion: {
-      """
-      struct S {
-        @Binding let number = 0
 
-        internal init() {
-        }
+      ✏️ Remove '= 0'
+      @MemberwiseInit
+      struct S {
+        @Binding @Init(default: 42) let number: Int
       }
       """
     }
   }
 
-  // FIXME: Exclusively applicable fix-its aren't testable: https://github.com/pointfreeco/swift-macro-testing/issues/14
   func testAttributedInitializedLet2() {
     assertMacro {
       """
       @MemberwiseInit
       struct S {
         @Binding @Init(default: T.q) let number = T.t
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        @Binding @Init(default: T.q) let number = T.t
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
@@ -246,54 +291,74 @@ final class CustomInitDefaultTests: XCTestCase {
       """
     } fixes: {
       """
+      @Binding @Init(default: T.q) let number = T.t
+                     ┬───────────
+                     ╰─ 🛑 @Init can't be applied to already initialized constant
+
+      ✏️ Remove '@Init(default: T.q)'
       @MemberwiseInit
       struct S {
         @Binding let number = T.t
       }
-      """
-    } expansion: {
-      """
-      struct S {
-        @Binding let number = T.t
 
-        internal init() {
-        }
+      ✏️ Remove '= T.t'
+      @MemberwiseInit
+      struct S {
+        @Binding @Init(default: T.q) let number: <#Type#>
       }
       """
     }
   }
 
-  // FIXME: Exclusively applicable fix-its aren't testable: https://github.com/pointfreeco/swift-macro-testing/issues/14
   func testAttributedInitializedVar() {
     assertMacro {
       """
       @MemberwiseInit
       struct S {
-        @Binding @Init(default: T.q) var number = T.t
+        @Binding @Init(default: 42) var number = 0
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        @Binding @Init(default: 42) var number = 0
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
       """
       @MemberwiseInit
       struct S {
-        @Binding @Init(default: T.q) var number = T.t
-                       ┬───────────
+        @Binding @Init(default: 42) var number = 0
+                       ┬──────────
                        ╰─ 🛑 Custom 'default' can't be applied to already initialized variable
-                          ✏️ Remove 'default: T.q'
-                          ✏️ Remove '= T.t'
+                          ✏️ Remove 'default: 42'
+                          ✏️ Remove '= 0'
       }
       """
     } fixes: {
       """
+      @Binding @Init(default: 42) var number = 0
+                     ┬──────────
+                     ╰─ 🛑 Custom 'default' can't be applied to already initialized variable
+
+      ✏️ Remove 'default: 42'
       @MemberwiseInit
       struct S {
-        @Binding @Init(default: T.q) var number: <#Type#>
+        @Binding @Init var number = 0
+      }
+
+      ✏️ Remove '= 0'
+      @MemberwiseInit
+      struct S {
+        @Binding @Init(default: 42) var number: Int
       }
       """
     }
   }
 
-  // FIXME: Exclusively applicable fix-its aren't testable: https://github.com/pointfreeco/swift-macro-testing/issues/14
   func testAttributedInitializedVar2() {
     assertMacro {
       """
@@ -302,6 +367,15 @@ final class CustomInitDefaultTests: XCTestCase {
         @Binding @Init(default: T.q) var number = T.t
       }
       """
+    } expansion: {
+      """
+      struct S {
+        @Binding @Init(default: T.q) var number = T.t
+
+        internal init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit
@@ -315,6 +389,17 @@ final class CustomInitDefaultTests: XCTestCase {
       """
     } fixes: {
       """
+      @Binding @Init(default: T.q) var number = T.t
+                     ┬───────────
+                     ╰─ 🛑 Custom 'default' can't be applied to already initialized variable
+
+      ✏️ Remove 'default: T.q'
+      @MemberwiseInit
+      struct S {
+        @Binding @Init var number = T.t
+      }
+
+      ✏️ Remove '= T.t'
       @MemberwiseInit
       struct S {
         @Binding @Init(default: T.q) var number: <#Type#>
@@ -323,7 +408,6 @@ final class CustomInitDefaultTests: XCTestCase {
     }
   }
 
-  // FIXME: Exclusively applicable fix-its aren't testable: https://github.com/pointfreeco/swift-macro-testing/issues/14
   // TODO: This test doesn't fit perfectly here because it touches on label
   func testInitializedVarCustomLabel() {
     assertMacro {
@@ -331,6 +415,15 @@ final class CustomInitDefaultTests: XCTestCase {
       @MemberwiseInit
       struct S {
         @Init(default: 42, label: "_") var number = 0
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        @Init(default: 42, label: "_") var number = 0
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
@@ -346,9 +439,20 @@ final class CustomInitDefaultTests: XCTestCase {
       """
     } fixes: {
       """
+      @Init(default: 42, label: "_") var number = 0
+            ┬───────────
+            ╰─ 🛑 Custom 'default' can't be applied to already initialized variable
+
+      ✏️ Remove 'default: 42'
       @MemberwiseInit
       struct S {
-        @Init(label: "_") 
+        @Init(label: "_") var number = 0
+      }
+
+      ✏️ Remove '= 0'
+      @MemberwiseInit
+      struct S {
+        @Init(default: 42, label: "_") var number: Int
       }
       """
     }
@@ -360,6 +464,15 @@ final class CustomInitDefaultTests: XCTestCase {
       @MemberwiseInit
       struct S {
         @Init(default: 42) let x, y: Int
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        @Init(default: 42) let x, y: Int
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
@@ -374,23 +487,14 @@ final class CustomInitDefaultTests: XCTestCase {
       """
     } fixes: {
       """
+      @Init(default: 42) let x, y: Int
+            ┬──────────
+            ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
+
+      ✏️ Remove '@Init(default: 42)'
       @MemberwiseInit
       struct S {
         let x, y: Int
-      }
-      """
-    } expansion: {
-      """
-      struct S {
-        let x, y: Int
-
-        internal init(
-          x: Int,
-          y: Int
-        ) {
-          self.x = x
-          self.y = y
-        }
       }
       """
     }
@@ -418,6 +522,15 @@ final class CustomInitDefaultTests: XCTestCase {
         @Init(default: 42) var x, y: Int
       }
       """
+    } expansion: {
+      """
+      struct S {
+        @Init(default: 42) var x, y: Int
+
+        internal init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit
@@ -430,23 +543,14 @@ final class CustomInitDefaultTests: XCTestCase {
       """
     } fixes: {
       """
+      @Init(default: 42) var x, y: Int
+            ┬──────────
+            ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
+
+      ✏️ Remove '@Init(default: 42)'
       @MemberwiseInit
       struct S {
         var x, y: Int
-      }
-      """
-    } expansion: {
-      """
-      struct S {
-        var x, y: Int
-
-        internal init(
-          x: Int,
-          y: Int
-        ) {
-          self.x = x
-          self.y = y
-        }
       }
       """
     }
@@ -474,6 +578,15 @@ final class CustomInitDefaultTests: XCTestCase {
         @Init(default: 42) let x = 0, y: Int
       }
       """
+    } expansion: {
+      """
+      struct S {
+        @Init(default: 42) let x = 0, y: Int
+
+        internal init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit
@@ -486,21 +599,14 @@ final class CustomInitDefaultTests: XCTestCase {
       """
     } fixes: {
       """
+      @Init(default: 42) let x = 0, y: Int
+            ┬──────────
+            ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
+
+      ✏️ Remove '@Init(default: 42)'
       @MemberwiseInit
       struct S {
         let x = 0, y: Int
-      }
-      """
-    } expansion: {
-      """
-      struct S {
-        let x = 0, y: Int
-
-        internal init(
-          y: Int
-        ) {
-          self.y = y
-        }
       }
       """
     }
@@ -526,6 +632,15 @@ final class CustomInitDefaultTests: XCTestCase {
         @Init(default: 42) var x = 0, y: Int
       }
       """
+    } expansion: {
+      """
+      struct S {
+        @Init(default: 42) var x = 0, y: Int
+
+        internal init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit
@@ -538,23 +653,14 @@ final class CustomInitDefaultTests: XCTestCase {
       """
     } fixes: {
       """
+      @Init(default: 42) var x = 0, y: Int
+            ┬──────────
+            ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
+
+      ✏️ Remove '@Init(default: 42)'
       @MemberwiseInit
       struct S {
         var x = 0, y: Int
-      }
-      """
-    } expansion: {
-      """
-      struct S {
-        var x = 0, y: Int
-
-        internal init(
-          x: Int = 0,
-          y: Int
-        ) {
-          self.x = x
-          self.y = y
-        }
       }
       """
     }
@@ -582,6 +688,15 @@ final class CustomInitDefaultTests: XCTestCase {
         @Init(default: 42) let x: Int, isOn: Bool
       }
       """
+    } expansion: {
+      """
+      struct S {
+        @Init(default: 42) let x: Int, isOn: Bool
+
+        internal init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit
@@ -594,23 +709,14 @@ final class CustomInitDefaultTests: XCTestCase {
       """
     } fixes: {
       """
+      @Init(default: 42) let x: Int, isOn: Bool
+            ┬──────────
+            ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
+
+      ✏️ Remove '@Init(default: 42)'
       @MemberwiseInit
       struct S {
         let x: Int, isOn: Bool
-      }
-      """
-    } expansion: {
-      """
-      struct S {
-        let x: Int, isOn: Bool
-
-        internal init(
-          x: Int,
-          isOn: Bool
-        ) {
-          self.x = x
-          self.isOn = isOn
-        }
       }
       """
     }

--- a/Tests/MemberwiseInitTests/CustomInitRawTests.swift
+++ b/Tests/MemberwiseInitTests/CustomInitRawTests.swift
@@ -63,13 +63,21 @@ final class CustomInitRawTests: XCTestCase {
     }
   }
 
-  // FIXME: Exclusively applicable fix-its aren't testable: https://github.com/pointfreeco/swift-macro-testing/issues/14
   func testDefaultOnInitializedLet() {
     assertMacro {
       """
       @MemberwiseInit
       struct S {
         @InitRaw(default: 42) let number = 0
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        let number = 0
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
@@ -85,18 +93,20 @@ final class CustomInitRawTests: XCTestCase {
       """
     } fixes: {
       """
+      @InitRaw(default: 42) let number = 0
+               ┬──────────
+               ╰─ 🛑 @InitRaw can't be applied to already initialized constant
+
+      ✏️ Remove '@InitRaw(default: 42)'
       @MemberwiseInit
       struct S {
         let number = 0
       }
-      """
-    } expansion: {
-      """
-      struct S {
-        let number = 0
 
-        internal init() {
-        }
+      ✏️ Remove '= 0'
+      @MemberwiseInit
+      struct S {
+        @InitRaw(default: 42) let number: Int
       }
       """
     }
@@ -188,7 +198,7 @@ final class CustomInitRawTests: XCTestCase {
   //        @Init(type: Q.self) var v: T
   //            ┬─────────────────
   //            ╰─ 🛑 Invalid use of metatype 'Q.self'. Expected a type, not its metatype.
-  //            ╰─ 🛑 Remove '.self'; type is expected, not a metatype.
+  //               ✏️ Remove '.self'; type is expected, not a metatype.
   //      }
   //      """
   //    }

--- a/Tests/MemberwiseInitTests/CustomInitTests.swift
+++ b/Tests/MemberwiseInitTests/CustomInitTests.swift
@@ -16,7 +16,6 @@ final class CustomInitTests: XCTestCase {
     }
   }
 
-  // FIXME: Exclusively applicable fix-its aren't testable: https://github.com/pointfreeco/swift-macro-testing/issues/14
   // TODO: For 1.0, diagnostic error on nonsensical @Init
   func testInitializedLet() {
     assertMacro {
@@ -24,6 +23,15 @@ final class CustomInitTests: XCTestCase {
       @MemberwiseInit
       struct S {
         @Init let number = 42
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        @Init let number = 42
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
@@ -39,18 +47,20 @@ final class CustomInitTests: XCTestCase {
       """
     } fixes: {
       """
+      @Init let number = 42
+      ┬────
+      ╰─ ⚠️ @Init can't be applied to already initialized constant
+
+      ✏️ Remove '@Init'
       @MemberwiseInit
       struct S {
         let number = 42
       }
-      """
-    } expansion: {
-      """
-      struct S {
-        let number = 42
 
-        internal init() {
-        }
+      ✏️ Remove '= 42'
+      @MemberwiseInit
+      struct S {
+        @Init let number: Int
       }
       """
     }
@@ -93,6 +103,15 @@ final class CustomInitTests: XCTestCase {
         @Init static var staticNumber: Int
       }
       """
+    } expansion: {
+      """
+      struct S {
+        @Init static var staticNumber: Int
+
+        internal init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit
@@ -105,18 +124,14 @@ final class CustomInitTests: XCTestCase {
       """
     } fixes: {
       """
+      @Init static var staticNumber: Int
+            ┬─────
+            ╰─ ⚠️ @Init can't be applied to 'static' members
+
+      ✏️ Remove '@Init'
       @MemberwiseInit
       struct S {
         static var staticNumber: Int
-      }
-      """
-    } expansion: {
-      """
-      struct S {
-        static var staticNumber: Int
-
-        internal init() {
-        }
       }
       """
     }
@@ -133,6 +148,17 @@ final class CustomInitTests: XCTestCase {
         }()
       }
       """
+    } expansion: {
+      """
+      struct S {
+        @Init(default: 0) lazy var lazyNumber: Int = {
+          return 2 * 2
+        }()
+
+        internal init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit
@@ -147,22 +173,16 @@ final class CustomInitTests: XCTestCase {
       """
     } fixes: {
       """
+      @Init(default: 0) lazy var lazyNumber: Int = {
+                        ┬───
+                        ╰─ ⚠️ @Init can't be applied to 'lazy' members
+
+      ✏️ Remove '@Init(default: 0)'
       @MemberwiseInit
       struct S {
         lazy var lazyNumber: Int = {
           return 2 * 2
         }()
-      }
-      """
-    } expansion: {
-      """
-      struct S {
-        lazy var lazyNumber: Int = {
-          return 2 * 2
-        }()
-
-        internal init() {
-        }
       }
       """
     }
@@ -179,6 +199,15 @@ final class CustomInitTests: XCTestCase {
         @Init lazy static var value = 0
       }
       """
+    } expansion: {
+      """
+      struct B {
+        @Init lazy static var value = 0
+
+        internal init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit
@@ -191,18 +220,14 @@ final class CustomInitTests: XCTestCase {
       """
     } fixes: {
       """
+      @Init lazy static var value = 0
+                 ┬─────
+                 ╰─ ⚠️ @Init can't be applied to 'static' members
+
+      ✏️ Remove '@Init'
       @MemberwiseInit
       struct B {
         lazy static var value = 0
-      }
-      """
-    } expansion: {
-      """
-      struct B {
-        lazy static var value = 0
-
-        internal init() {
-        }
       }
       """
     }

--- a/Tests/MemberwiseInitTests/InvalidSyntaxTests.swift
+++ b/Tests/MemberwiseInitTests/InvalidSyntaxTests.swift
@@ -77,6 +77,21 @@ final class InvalidSyntaxTests: XCTestCase {
         let x: T
       }
       """
+    } expansion: {
+      """
+      struct S {
+        @Init(label: "x") let x: T
+        let x: T
+
+        internal init(
+          x: T,
+          x: T
+        ) {
+          self.x = x
+          self.x = x
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit

--- a/Tests/MemberwiseInitTests/LayeredDiagnosticsTests.swift
+++ b/Tests/MemberwiseInitTests/LayeredDiagnosticsTests.swift
@@ -24,6 +24,15 @@ final class LayeredDiagnosticsTests: XCTestCase {
         @Init(label: "$foo") let x, y: T
       }
       """
+    } expansion: {
+      """
+      struct S {
+        @Init(label: "$foo") let x, y: T
+
+        internal init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit
@@ -44,6 +53,15 @@ final class LayeredDiagnosticsTests: XCTestCase {
         @Init(default: 0, label: "$foo") let x, y: T
       }
       """
+    } expansion: {
+      """
+      struct S {
+        @Init(default: 0, label: "$foo") let x, y: T
+
+        internal init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit
@@ -54,6 +72,18 @@ final class LayeredDiagnosticsTests: XCTestCase {
               ┬──────────
               ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
                  ✏️ Remove 'default: 0'
+      }
+      """
+    } fixes: {
+      """
+      @Init(default: 0, label: "$foo") let x, y: T
+            ┬──────────
+            ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
+
+      ✏️ Remove 'default: 0'
+      @MemberwiseInit
+      struct S {
+        @Init(label: "$foo") let x, y: T
       }
       """
     }
@@ -67,6 +97,15 @@ final class LayeredDiagnosticsTests: XCTestCase {
         @Init(default: 0, label: "$foo") private let x, y: T
       }
       """
+    } expansion: {
+      """
+      struct S {
+        @Init(default: 0, label: "$foo") private let x, y: T
+
+        public init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit(.public)
@@ -74,11 +113,48 @@ final class LayeredDiagnosticsTests: XCTestCase {
         @Init(default: 0, label: "$foo") private let x, y: T
                                          ┬──────
               │           │              ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
+              │           │                 ✏️ Add '@Init(.public)'
+              │           │                 ✏️ Replace 'private' access with 'public'
+              │           │                 ✏️ Add '@Init(.ignore)' and an initializer
                           ┬────────────
               │           ╰─ 🛑 Custom 'label' can't be applied to multiple bindings
               ┬──────────
               ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
                  ✏️ Remove 'default: 0'
+      }
+      """
+    } fixes: {
+      """
+      @Init(default: 0, label: "$foo") private let x, y: T
+            ┬──────────
+            ╰─ 🛑 Custom 'default' can't be applied to multiple bindings
+
+      ✏️ Remove 'default: 0'
+      @MemberwiseInit(.public)
+      struct S {
+        @Init(label: "$foo") private let x, y: T
+      }
+
+      @Init(default: 0, label: "$foo") private let x, y: T
+                                       ┬──────
+                                       ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
+
+      ✏️ Add '@Init(.public)'
+      @MemberwiseInit(.public)
+      struct S {
+        @Init(.public, default: 0, label: "$foo") private let x, y: T
+      }
+
+      ✏️ Replace 'private' access with 'public'
+      @MemberwiseInit(.public)
+      struct S {
+        @Init(default: 0, label: "$foo") public let x, y: T
+      }
+
+      ✏️ Add '@Init(.ignore)' and an initializer
+      @MemberwiseInit(.public)
+      struct S {
+        @Init(.ignore) private let x = <#value#>, y: T = <#value#>
       }
       """
     }
@@ -93,6 +169,16 @@ final class LayeredDiagnosticsTests: XCTestCase {
         @Init(label: "foo") let y: T
       }
       """
+    } expansion: {
+      """
+      struct S {
+        @Init(label: "foo") let x: T
+        @Init(label: "foo") let y: T
+
+        public init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit(.public)
@@ -100,9 +186,67 @@ final class LayeredDiagnosticsTests: XCTestCase {
         @Init(label: "foo") let x: T
         ┬───────────────────────────
         ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+           ✏️ Add '@Init(.public)'
+           ✏️ Add 'public' access level
+           ✏️ Add '@Init(.ignore)' and an initializer
         @Init(label: "foo") let y: T
         ┬───────────────────────────
         ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+           ✏️ Add '@Init(.public)'
+           ✏️ Add 'public' access level
+           ✏️ Add '@Init(.ignore)' and an initializer
+      }
+      """
+    } fixes: {
+      """
+      @Init(label: "foo") let x: T
+      ┬───────────────────────────
+      ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+
+      ✏️ Add '@Init(.public)'
+      @MemberwiseInit(.public)
+      struct S {
+        @Init(.public, label: "foo") let x: T
+        @Init(label: "foo") let y: T
+      }
+
+      ✏️ Add 'public' access level
+      @MemberwiseInit(.public)
+      struct S {
+        @Init(label: "foo") public let x: T
+        @Init(label: "foo") let y: T
+      }
+
+      ✏️ Add '@Init(.ignore)' and an initializer
+      @MemberwiseInit(.public)
+      struct S {
+        @Init(.ignore) let x: T = <#value#>
+        @Init(label: "foo") let y: T
+      }
+
+      @Init(label: "foo") let y: T
+      ┬───────────────────────────
+      ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+
+      ✏️ Add '@Init(.public)'
+      @MemberwiseInit(.public)
+      struct S {
+        @Init(label: "foo") let x: T
+        @Init(.public, label: "foo") let y: T
+      }
+
+      ✏️ Add 'public' access level
+      @MemberwiseInit(.public)
+      struct S {
+        @Init(label: "foo") let x: T
+        @Init(label: "foo") public let y: T
+      }
+
+      ✏️ Add '@Init(.ignore)' and an initializer
+      @MemberwiseInit(.public)
+      struct S {
+        @Init(label: "foo") let x: T
+        @Init(.ignore) let y: T = <#value#>
       }
       """
     }
@@ -117,6 +261,16 @@ final class LayeredDiagnosticsTests: XCTestCase {
         let y: T
       }
       """
+    } expansion: {
+      """
+      struct S {
+        @Init(label: "y") let x: T
+        let y: T
+
+        public init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit(.public)
@@ -124,9 +278,67 @@ final class LayeredDiagnosticsTests: XCTestCase {
         @Init(label: "y") let x: T
         ┬─────────────────────────
         ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+           ✏️ Add '@Init(.public)'
+           ✏️ Add 'public' access level
+           ✏️ Add '@Init(.ignore)' and an initializer
         let y: T
         ┬───────
         ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+           ✏️ Add '@Init(.public)'
+           ✏️ Add 'public' access level
+           ✏️ Add '@Init(.ignore)' and an initializer
+      }
+      """
+    } fixes: {
+      """
+      @Init(label: "y") let x: T
+      ┬─────────────────────────
+      ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+
+      ✏️ Add '@Init(.public)'
+      @MemberwiseInit(.public)
+      struct S {
+        @Init(.public, label: "y") let x: T
+        let y: T
+      }
+
+      ✏️ Add 'public' access level
+      @MemberwiseInit(.public)
+      struct S {
+        @Init(label: "y") public let x: T
+        let y: T
+      }
+
+      ✏️ Add '@Init(.ignore)' and an initializer
+      @MemberwiseInit(.public)
+      struct S {
+        @Init(.ignore) let x: T = <#value#>
+        let y: T
+      }
+
+      let y: T
+      ┬───────
+      ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+
+      ✏️ Add '@Init(.public)'
+      @MemberwiseInit(.public)
+      struct S {
+        @Init(label: "y") let x: T
+        @Init(.public) let y: T
+      }
+
+      ✏️ Add 'public' access level
+      @MemberwiseInit(.public)
+      struct S {
+        @Init(label: "y") let x: T
+        public let y: T
+      }
+
+      ✏️ Add '@Init(.ignore)' and an initializer
+      @MemberwiseInit(.public)
+      struct S {
+        @Init(label: "y") let x: T
+        @Init(.ignore) let y: T = <#value#>
       }
       """
     }

--- a/Tests/MemberwiseInitTests/MemberwiseInitAccessLevelTests.swift
+++ b/Tests/MemberwiseInitTests/MemberwiseInitAccessLevelTests.swift
@@ -22,7 +22,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PrivateStruct_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       private struct S {
@@ -45,7 +45,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PrivateStruct_InitPrivate_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       private struct S {
@@ -68,7 +68,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PrivateStruct_InitInternal_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       private struct S {
@@ -91,7 +91,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PrivateStruct_InitPublic_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       private struct S {
@@ -114,7 +114,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PrivateStruct_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       private struct S {
@@ -137,7 +137,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PrivateStruct_InitPrivate_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       private struct S {
@@ -160,7 +160,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PrivateStruct_InitInternal_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       private struct S {
@@ -183,7 +183,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PrivateStruct_InitPublic_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       private struct S {
@@ -206,7 +206,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PrivateStruct_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       private struct S {
@@ -229,7 +229,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PrivateStruct_InitPrivate_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       private struct S {
@@ -252,7 +252,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PrivateStruct_InitInternal_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       private struct S {
@@ -275,7 +275,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PrivateStruct_InitPublic_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       private struct S {
@@ -298,7 +298,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PrivateStruct_NoProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       private struct S {
@@ -316,7 +316,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_DefaultStruct_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       struct S {
@@ -339,7 +339,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_DefaultStruct_InitPrivate_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       struct S {
@@ -362,7 +362,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_DefaultStruct_InitInternal_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       struct S {
@@ -385,7 +385,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_DefaultStruct_InitPublic_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       struct S {
@@ -408,7 +408,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_DefaultStruct_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       struct S {
@@ -431,7 +431,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_DefaultStruct_InitPrivate_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       struct S {
@@ -454,7 +454,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_DefaultStruct_InitInternal_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       struct S {
@@ -477,7 +477,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_DefaultStruct_InitPublic_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       struct S {
@@ -500,7 +500,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_DefaultStruct_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       struct S {
@@ -523,7 +523,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_DefaultStruct_InitPrivate_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       struct S {
@@ -546,7 +546,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_DefaultStruct_InitInternal_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       struct S {
@@ -569,7 +569,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_DefaultStruct_InitPublic_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       struct S {
@@ -592,7 +592,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_DefaultStruct_NoProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       struct S {
@@ -610,7 +610,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PublicStruct_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       public struct S {
@@ -633,7 +633,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PublicStruct_InitPrivate_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       public struct S {
@@ -656,7 +656,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PublicStruct_InitInternal_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       public struct S {
@@ -679,7 +679,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PublicStruct_InitPublic_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       public struct S {
@@ -702,7 +702,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PublicStruct_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       public struct S {
@@ -725,7 +725,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PublicStruct_InitPrivate_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       public struct S {
@@ -748,7 +748,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PublicStruct_InitInternal_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       public struct S {
@@ -771,7 +771,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PublicStruct_InitPublic_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       public struct S {
@@ -794,7 +794,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PublicStruct_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       public struct S {
@@ -817,7 +817,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PublicStruct_InitPrivate_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       public struct S {
@@ -840,7 +840,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PublicStruct_InitInternal_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       public struct S {
@@ -863,7 +863,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PublicStruct_InitPublic_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       public struct S {
@@ -886,7 +886,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPrivate_PublicStruct_NoProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.private)
       public struct S {
@@ -904,11 +904,20 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_PrivateStruct_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       private struct S {
         private let v: T
+      }
+      """
+    } expansion: {
+      """
+      private struct S {
+        private let v: T
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
@@ -918,17 +927,29 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         private let v: T
         ┬──────
         ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
+           ✏️ Add '@Init(.internal)'
+           ✏️ Replace 'private' access with 'internal'
+           ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitDefault_PrivateStruct_InitPrivate_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       private struct S {
         @Init(.private) private let v: T
+      }
+      """
+    } expansion: {
+      """
+      private struct S {
+        private let v: T
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
@@ -938,13 +959,15 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) private let v: T
               ┬───────
               ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
+                 ✏️ Add '@Init(.internal)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitDefault_PrivateStruct_InitInternal_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       private struct S {
@@ -967,7 +990,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_PrivateStruct_InitPublic_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       private struct S {
@@ -990,11 +1013,20 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_PrivateStruct_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       private struct S {
         let v: T
+      }
+      """
+    } expansion: {
+      """
+      private struct S {
+        let v: T
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
@@ -1004,17 +1036,29 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         let v: T
         ┬───────
         ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
+           ✏️ Add '@Init(.internal)'
+           ✏️ Add 'internal' access level
+           ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitDefault_PrivateStruct_InitPrivate_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       private struct S {
         @Init(.private) let v: T
+      }
+      """
+    } expansion: {
+      """
+      private struct S {
+        let v: T
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
@@ -1024,13 +1068,15 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) let v: T
               ┬───────
               ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
+                 ✏️ Add '@Init(.internal)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitDefault_PrivateStruct_InitInternal_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       private struct S {
@@ -1053,7 +1099,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_PrivateStruct_InitPublic_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       private struct S {
@@ -1076,7 +1122,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_PrivateStruct_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       private struct S {
@@ -1099,11 +1145,20 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_PrivateStruct_InitPrivate_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       private struct S {
         @Init(.private) public let v: T
+      }
+      """
+    } expansion: {
+      """
+      private struct S {
+        public let v: T
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
@@ -1113,13 +1168,15 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) public let v: T
               ┬───────
               ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
+                 ✏️ Add '@Init(.internal)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitDefault_PrivateStruct_InitInternal_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       private struct S {
@@ -1142,7 +1199,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_PrivateStruct_InitPublic_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       private struct S {
@@ -1165,7 +1222,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_PrivateStruct_NoProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       private struct S {
@@ -1183,11 +1240,20 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_DefaultStruct_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       struct S {
         private let v: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        private let v: T
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
@@ -1197,17 +1263,29 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         private let v: T
         ┬──────
         ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
+           ✏️ Add '@Init(.internal)'
+           ✏️ Replace 'private' access with 'internal'
+           ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitDefault_DefaultStruct_InitPrivate_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       struct S {
         @Init(.private) private let v: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        private let v: T
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
@@ -1217,13 +1295,15 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) private let v: T
               ┬───────
               ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
+                 ✏️ Add '@Init(.internal)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitDefault_DefaultStruct_InitInternal_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       struct S {
@@ -1246,7 +1326,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_DefaultStruct_InitPublic_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       struct S {
@@ -1269,7 +1349,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_DefaultStruct_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       struct S {
@@ -1292,11 +1372,20 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_DefaultStruct_InitPrivate_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       struct S {
         @Init(.private) let v: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        let v: T
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
@@ -1306,13 +1395,15 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) let v: T
               ┬───────
               ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
+                 ✏️ Add '@Init(.internal)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitDefault_DefaultStruct_InitInternal_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       struct S {
@@ -1335,7 +1426,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_DefaultStruct_InitPublic_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       struct S {
@@ -1358,7 +1449,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_DefaultStruct_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       struct S {
@@ -1381,11 +1472,20 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_DefaultStruct_InitPrivate_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       struct S {
         @Init(.private) public let v: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        public let v: T
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
@@ -1395,13 +1495,15 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) public let v: T
               ┬───────
               ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
+                 ✏️ Add '@Init(.internal)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitDefault_DefaultStruct_InitInternal_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       struct S {
@@ -1424,7 +1526,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_DefaultStruct_InitPublic_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       struct S {
@@ -1447,7 +1549,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_DefaultStruct_NoProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       struct S {
@@ -1465,11 +1567,20 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_PublicStruct_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       public struct S {
         private let v: T
+      }
+      """
+    } expansion: {
+      """
+      public struct S {
+        private let v: T
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
@@ -1479,17 +1590,29 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         private let v: T
         ┬──────
         ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
+           ✏️ Add '@Init(.internal)'
+           ✏️ Replace 'private' access with 'internal'
+           ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitDefault_PublicStruct_InitPrivate_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       public struct S {
         @Init(.private) private let v: T
+      }
+      """
+    } expansion: {
+      """
+      public struct S {
+        private let v: T
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
@@ -1499,13 +1622,15 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) private let v: T
               ┬───────
               ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
+                 ✏️ Add '@Init(.internal)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitDefault_PublicStruct_InitInternal_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       public struct S {
@@ -1528,7 +1653,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_PublicStruct_InitPublic_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       public struct S {
@@ -1551,7 +1676,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_PublicStruct_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       public struct S {
@@ -1574,11 +1699,20 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_PublicStruct_InitPrivate_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       public struct S {
         @Init(.private) let v: T
+      }
+      """
+    } expansion: {
+      """
+      public struct S {
+        let v: T
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
@@ -1588,13 +1722,15 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) let v: T
               ┬───────
               ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
+                 ✏️ Add '@Init(.internal)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitDefault_PublicStruct_InitInternal_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       public struct S {
@@ -1617,7 +1753,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_PublicStruct_InitPublic_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       public struct S {
@@ -1640,7 +1776,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_PublicStruct_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       public struct S {
@@ -1663,11 +1799,20 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_PublicStruct_InitPrivate_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       public struct S {
         @Init(.private) public let v: T
+      }
+      """
+    } expansion: {
+      """
+      public struct S {
+        public let v: T
+
+        internal init() {
+        }
       }
       """
     } diagnostics: {
@@ -1677,13 +1822,15 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) public let v: T
               ┬───────
               ╰─ 🛑 @MemberwiseInit(.internal) would leak access to 'private' property
+                 ✏️ Add '@Init(.internal)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitDefault_PublicStruct_InitInternal_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       public struct S {
@@ -1706,7 +1853,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_PublicStruct_InitPublic_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       public struct S {
@@ -1729,7 +1876,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitDefault_PublicStruct_NoProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit
       public struct S {
@@ -1747,11 +1894,20 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPublic_PrivateStruct_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       private struct S {
         private let v: T
+      }
+      """
+    } expansion: {
+      """
+      private struct S {
+        private let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -1761,17 +1917,29 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         private let v: T
         ┬──────
         ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
+           ✏️ Add '@Init(.public)'
+           ✏️ Replace 'private' access with 'public'
+           ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_PrivateStruct_InitPrivate_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       private struct S {
         @Init(.private) private let v: T
+      }
+      """
+    } expansion: {
+      """
+      private struct S {
+        private let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -1781,17 +1949,28 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) private let v: T
               ┬───────
               ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
+                 ✏️ Add '@Init(.public)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_PrivateStruct_InitInternal_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       private struct S {
         @Init(.internal) private let v: T
+      }
+      """
+    } expansion: {
+      """
+      private struct S {
+        private let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -1801,13 +1980,15 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.internal) private let v: T
               ┬────────
               ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+                 ✏️ Add '@Init(.public)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_PrivateStruct_InitPublic_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       private struct S {
@@ -1830,11 +2011,20 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPublic_PrivateStruct_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       private struct S {
         let v: T
+      }
+      """
+    } expansion: {
+      """
+      private struct S {
+        let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -1844,17 +2034,29 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         let v: T
         ┬───────
         ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
+           ✏️ Add '@Init(.public)'
+           ✏️ Add 'public' access level
+           ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_PrivateStruct_InitPrivate_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       private struct S {
         @Init(.private) let v: T
+      }
+      """
+    } expansion: {
+      """
+      private struct S {
+        let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -1864,17 +2066,28 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) let v: T
               ┬───────
               ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
+                 ✏️ Add '@Init(.public)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_PrivateStruct_InitInternal_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       private struct S {
         @Init(.internal) let v: T
+      }
+      """
+    } expansion: {
+      """
+      private struct S {
+        let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -1884,13 +2097,15 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.internal) let v: T
               ┬────────
               ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+                 ✏️ Add '@Init(.public)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_PrivateStruct_InitPublic_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       private struct S {
@@ -1913,7 +2128,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPublic_PrivateStruct_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       private struct S {
@@ -1936,11 +2151,20 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPublic_PrivateStruct_InitPrivate_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       private struct S {
         @Init(.private) public let v: T
+      }
+      """
+    } expansion: {
+      """
+      private struct S {
+        public let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -1950,17 +2174,28 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) public let v: T
               ┬───────
               ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
+                 ✏️ Add '@Init(.public)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_PrivateStruct_InitInternal_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       private struct S {
         @Init(.internal) public let v: T
+      }
+      """
+    } expansion: {
+      """
+      private struct S {
+        public let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -1970,13 +2205,15 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.internal) public let v: T
               ┬────────
               ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+                 ✏️ Add '@Init(.public)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_PrivateStruct_InitPublic_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       private struct S {
@@ -1999,7 +2236,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPublic_PrivateStruct_NoProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       private struct S {
@@ -2017,11 +2254,20 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPublic_DefaultStruct_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       struct S {
         private let v: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        private let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -2031,17 +2277,29 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         private let v: T
         ┬──────
         ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
+           ✏️ Add '@Init(.public)'
+           ✏️ Replace 'private' access with 'public'
+           ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_DefaultStruct_InitPrivate_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       struct S {
         @Init(.private) private let v: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        private let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -2051,17 +2309,28 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) private let v: T
               ┬───────
               ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
+                 ✏️ Add '@Init(.public)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_DefaultStruct_InitInternal_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       struct S {
         @Init(.internal) private let v: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        private let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -2071,13 +2340,15 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.internal) private let v: T
               ┬────────
               ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+                 ✏️ Add '@Init(.public)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_DefaultStruct_InitPublic_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       struct S {
@@ -2100,11 +2371,20 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPublic_DefaultStruct_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       struct S {
         let v: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -2114,17 +2394,29 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         let v: T
         ┬───────
         ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+           ✏️ Add '@Init(.public)'
+           ✏️ Add 'public' access level
+           ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_DefaultStruct_InitPrivate_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       struct S {
         @Init(.private) let v: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -2134,17 +2426,28 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) let v: T
               ┬───────
               ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
+                 ✏️ Add '@Init(.public)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_DefaultStruct_InitInternal_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       struct S {
         @Init(.internal) let v: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -2154,13 +2457,15 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.internal) let v: T
               ┬────────
               ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+                 ✏️ Add '@Init(.public)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_DefaultStruct_InitPublic_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       struct S {
@@ -2183,7 +2488,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPublic_DefaultStruct_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       struct S {
@@ -2206,11 +2511,20 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPublic_DefaultStruct_InitPrivate_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       struct S {
         @Init(.private) public let v: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        public let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -2220,17 +2534,28 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) public let v: T
               ┬───────
               ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
+                 ✏️ Add '@Init(.public)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_DefaultStruct_InitInternal_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       struct S {
         @Init(.internal) public let v: T
+      }
+      """
+    } expansion: {
+      """
+      struct S {
+        public let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -2240,13 +2565,15 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.internal) public let v: T
               ┬────────
               ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+                 ✏️ Add '@Init(.public)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_DefaultStruct_InitPublic_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       struct S {
@@ -2269,7 +2596,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPublic_DefaultStruct_NoProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       struct S {
@@ -2287,11 +2614,20 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPublic_PublicStruct_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       public struct S {
         private let v: T
+      }
+      """
+    } expansion: {
+      """
+      public struct S {
+        private let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -2301,17 +2637,29 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         private let v: T
         ┬──────
         ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
+           ✏️ Add '@Init(.public)'
+           ✏️ Replace 'private' access with 'public'
+           ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_PublicStruct_InitPrivate_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       public struct S {
         @Init(.private) private let v: T
+      }
+      """
+    } expansion: {
+      """
+      public struct S {
+        private let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -2321,17 +2669,28 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) private let v: T
               ┬───────
               ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
+                 ✏️ Add '@Init(.public)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_PublicStruct_InitInternal_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       public struct S {
         @Init(.internal) private let v: T
+      }
+      """
+    } expansion: {
+      """
+      public struct S {
+        private let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -2341,13 +2700,15 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.internal) private let v: T
               ┬────────
               ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+                 ✏️ Add '@Init(.public)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_PublicStruct_InitPublic_PrivateProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       public struct S {
@@ -2370,11 +2731,20 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPublic_PublicStruct_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       public struct S {
         let v: T
+      }
+      """
+    } expansion: {
+      """
+      public struct S {
+        let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -2384,17 +2754,29 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         let v: T
         ┬───────
         ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+           ✏️ Add '@Init(.public)'
+           ✏️ Add 'public' access level
+           ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_PublicStruct_InitPrivate_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       public struct S {
         @Init(.private) let v: T
+      }
+      """
+    } expansion: {
+      """
+      public struct S {
+        let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -2404,17 +2786,28 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) let v: T
               ┬───────
               ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
+                 ✏️ Add '@Init(.public)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_PublicStruct_InitInternal_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       public struct S {
         @Init(.internal) let v: T
+      }
+      """
+    } expansion: {
+      """
+      public struct S {
+        let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -2424,13 +2817,15 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.internal) let v: T
               ┬────────
               ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+                 ✏️ Add '@Init(.public)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_PublicStruct_InitPublic_DefaultProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       public struct S {
@@ -2453,7 +2848,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPublic_PublicStruct_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       public struct S {
@@ -2476,11 +2871,20 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPublic_PublicStruct_InitPrivate_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       public struct S {
         @Init(.private) public let v: T
+      }
+      """
+    } expansion: {
+      """
+      public struct S {
+        public let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -2490,17 +2894,28 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.private) public let v: T
               ┬───────
               ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'private' property
+                 ✏️ Add '@Init(.public)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_PublicStruct_InitInternal_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       public struct S {
         @Init(.internal) public let v: T
+      }
+      """
+    } expansion: {
+      """
+      public struct S {
+        public let v: T
+
+        public init() {
+        }
       }
       """
     } diagnostics: {
@@ -2510,13 +2925,15 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
         @Init(.internal) public let v: T
               ┬────────
               ╰─ 🛑 @MemberwiseInit(.public) would leak access to 'internal' property
+                 ✏️ Add '@Init(.public)'
+                 ✏️ Add '@Init(.ignore)' and an initializer
       }
       """
     }
   }
 
   func testMemberwiseInitPublic_PublicStruct_InitPublic_PublicProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       public struct S {
@@ -2539,7 +2956,7 @@ final class MemberwiseInitAccessLevelTests: XCTestCase {
   }
 
   func testMemberwiseInitPublic_PublicStruct_NoProperty() {
-    assertMacro {
+    assertMacro(applyFixIts: false) {
       """
       @MemberwiseInit(.public)
       public struct S {

--- a/Tests/MemberwiseInitTests/MemberwiseInitDeprecationTests.swift
+++ b/Tests/MemberwiseInitTests/MemberwiseInitDeprecationTests.swift
@@ -27,6 +27,18 @@ final class MemberwiseInitDeprecationTests: XCTestCase {
         @Init(.escaping) var value: T
       }
       """
+    } expansion: {
+      """
+      struct S {
+        var value: T
+
+        internal init(
+          value: @escaping T
+        ) {
+          self.value = value
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit
@@ -39,21 +51,14 @@ final class MemberwiseInitDeprecationTests: XCTestCase {
       """
     } fixes: {
       """
+      @Init(.escaping) var value: T
+            ┬────────
+            ╰─ ⚠️ @Init(.escaping) is deprecated
+
+      ✏️ Replace '@Init(.escaping)' with '@Init(escaping: true)'
       @MemberwiseInit
       struct S {
         @Init(escaping: true) var value: T
-      }
-      """
-    } expansion: {
-      """
-      struct S {
-        var value: T
-
-        internal init(
-          value: @escaping T
-        ) {
-          self.value = value
-        }
       }
       """
     }
@@ -68,6 +73,18 @@ final class MemberwiseInitDeprecationTests: XCTestCase {
         @Init(.public, .escaping) var value: T
       }
       """
+    } expansion: {
+      """
+      struct S {
+        var value: T
+
+        internal init(
+          value: @escaping T
+        ) {
+          self.value = value
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit
@@ -80,21 +97,14 @@ final class MemberwiseInitDeprecationTests: XCTestCase {
       """
     } fixes: {
       """
+      @Init(.public, .escaping) var value: T
+            ┬─────────────────
+            ╰─ ⚠️ @Init(.escaping) is deprecated
+
+      ✏️ Replace '@Init(.escaping)' with '@Init(escaping: true)'
       @MemberwiseInit
       struct S {
         @Init(.public, escaping: true) var value: T
-      }
-      """
-    } expansion: {
-      """
-      struct S {
-        var value: T
-
-        internal init(
-          value: @escaping T
-        ) {
-          self.value = value
-        }
       }
       """
     }
@@ -109,6 +119,18 @@ final class MemberwiseInitDeprecationTests: XCTestCase {
         @Init(.escaping, label: "_") var value: T
       }
       """
+    } expansion: {
+      """
+      struct S {
+        var value: T
+
+        internal init(
+          _ value: @escaping T
+        ) {
+          self.value = value
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit
@@ -121,21 +143,14 @@ final class MemberwiseInitDeprecationTests: XCTestCase {
       """
     } fixes: {
       """
+      @Init(.escaping, label: "_") var value: T
+            ┬────────────────────
+            ╰─ ⚠️ @Init(.escaping) is deprecated
+
+      ✏️ Replace '@Init(.escaping)' with '@Init(escaping: true)'
       @MemberwiseInit
       struct S {
         @Init(escaping: true, label: "_") var value: T
-      }
-      """
-    } expansion: {
-      """
-      struct S {
-        var value: T
-
-        internal init(
-          _ value: @escaping T
-        ) {
-          self.value = value
-        }
       }
       """
     }
@@ -150,6 +165,18 @@ final class MemberwiseInitDeprecationTests: XCTestCase {
         @Init(.public, .escaping, label: "_") var value: T
       }
       """
+    } expansion: {
+      """
+      struct S {
+        var value: T
+
+        internal init(
+          _ value: @escaping T
+        ) {
+          self.value = value
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit
@@ -162,21 +189,14 @@ final class MemberwiseInitDeprecationTests: XCTestCase {
       """
     } fixes: {
       """
+      @Init(.public, .escaping, label: "_") var value: T
+            ┬─────────────────────────────
+            ╰─ ⚠️ @Init(.escaping) is deprecated
+
+      ✏️ Replace '@Init(.escaping)' with '@Init(escaping: true)'
       @MemberwiseInit
       struct S {
         @Init(.public, escaping: true, label: "_") var value: T
-      }
-      """
-    } expansion: {
-      """
-      struct S {
-        var value: T
-
-        internal init(
-          _ value: @escaping T
-        ) {
-          self.value = value
-        }
       }
       """
     }

--- a/Tests/MemberwiseInitTests/MemberwiseInitInferredTypeTests.swift
+++ b/Tests/MemberwiseInitTests/MemberwiseInitInferredTypeTests.swift
@@ -26,6 +26,16 @@ final class MemberwiseInitInferredTypeTests: XCTestCase {
         var stepsToday = number
       }
       """
+    } expansion: {
+      """
+      let number = 0
+      public struct Pedometer {
+        var stepsToday = number
+
+        internal init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       let number = 0
@@ -424,6 +434,15 @@ final class MemberwiseInitInferredTypeTests: XCTestCase {
         var array = [1 as Int, 2 as Double]
       }
       """##
+    } expansion: {
+      """
+      struct S {
+        var array = [1 as Int, 2 as Double]
+
+        internal init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit
@@ -468,6 +487,16 @@ final class MemberwiseInitInferredTypeTests: XCTestCase {
         var array = [1, number, 3]
       }
       """##
+    } expansion: {
+      """
+      let number = 2
+      public struct S {
+        var array = [1, number, 3]
+
+        internal init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       let number = 2
@@ -515,6 +544,15 @@ final class MemberwiseInitInferredTypeTests: XCTestCase {
         var array = [1, "foo", 3]
       }
       """##
+    } expansion: {
+      """
+      public struct S {
+        var array = [1, "foo", 3]
+
+        internal init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit
@@ -585,6 +623,17 @@ final class MemberwiseInitInferredTypeTests: XCTestCase {
         var dictionary = ["key1": foo, "key2": bar]
       }
       """##
+    } expansion: {
+      """
+      let foo = "foo"
+      let bar = "bar"
+      public struct S {
+        var dictionary = ["key1": foo, "key2": bar]
+
+        internal init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       let foo = "foo"
@@ -608,6 +657,16 @@ final class MemberwiseInitInferredTypeTests: XCTestCase {
         var dictionary = ["foo": 1, bar: 2]
       }
       """##
+    } expansion: {
+      """
+      let bar = "bar"
+      public struct S {
+        var dictionary = ["foo": 1, bar: 2]
+
+        internal init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       let bar = "bar"
@@ -677,6 +736,15 @@ final class MemberwiseInitInferredTypeTests: XCTestCase {
         var array = [1 as Int: 2 as Double, 1.0: 2]
       }
       """##
+    } expansion: {
+      """
+      struct S {
+        var array = [1 as Int: 2 as Double, 1.0: 2]
+
+        internal init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit
@@ -725,6 +793,15 @@ final class MemberwiseInitInferredTypeTests: XCTestCase {
         var dictionary = ["foo": 1, 3: "bar"]
       }
       """##
+    } expansion: {
+      """
+      public struct S {
+        var dictionary = ["foo": 1, 3: "bar"]
+
+        internal init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit
@@ -794,6 +871,16 @@ final class MemberwiseInitInferredTypeTests: XCTestCase {
         var tuple = (1, name, true)
       }
       """##
+    } expansion: {
+      """
+      let name = "Blob"
+      public struct S {
+        var tuple = (1, name, true)
+
+        internal init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       let name = "Blob"
@@ -1017,6 +1104,16 @@ final class MemberwiseInitInferredTypeTests: XCTestCase {
         var range = start...5
       }
       """##
+    } expansion: {
+      """
+      let start = 0
+      public struct S {
+        var range = start...5
+
+        internal init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       let start = 0
@@ -1078,6 +1175,15 @@ final class MemberwiseInitInferredTypeTests: XCTestCase {
         var bitwiseAnd = 0b1010 & 1.0
       }
       """##
+    } expansion: {
+      """
+      public struct S {
+        var bitwiseAnd = 0b1010 & 1.0
+
+        internal init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit
@@ -1189,6 +1295,15 @@ final class MemberwiseInitInferredTypeTests: XCTestCase {
         var modulo = 10 % 3.0
       }
       """##
+    } expansion: {
+      """
+      public struct S {
+        var modulo = 10 % 3.0
+
+        internal init() {
+        }
+      }
+      """
     } diagnostics: {
       """
       @MemberwiseInit

--- a/bin/generate_access_level_tests.sh
+++ b/bin/generate_access_level_tests.sh
@@ -89,7 +89,7 @@ capitalize() {
           test_name="${test_name//__/_}"
 
           echo "  func $test_name() {"
-          echo "    assertMacro {"
+          echo "    assertMacro(applyFixIts: false) {"
           echo "      \"\"\""
           echo "      @MemberwiseInit${memberwise_str:+($memberwise_str)}"
           echo "      ${struct_str}${struct_str:+ }struct S {"


### PR DESCRIPTION
* Add fix-its for access level leaks; update tests with full fix-it coverage
* Add forked and vendored MacroTesting
    * Always snapshot the original expanded source, even when the expansion
      includes diagnostics. (Moved `expansion` to be the first snapshot
      closure, not the last.)
    * Omit `expansion` if the original source didn't expand. (That is, the
      "expanded" source is identical to the source resulting from merely
      removing the macro attributes.)
    * Never automatically re-expand fixed source. (Require users to add a
      separate `assertMacro` statement, if fixed source isn't already tested
      elsewhere.)
    * Fix-its that can't be simulateously applied are now testable.
    * Changed the `fixes` string format to snapshot fixes individually.
    * Always snapshot the fixes, even when not all diagnostics have a
      fix-it.
    * Add an option to skip applying fix-its, e.g. when fix-it application
      is already covered by other tests.