### PR TITLE
Beta support for Swift Testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,15 @@ on:
       - main
   pull_request:
     branches:
-      - '*'
+      - "*"
   workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
+
+env:
+  SNAPSHOT_TESTING_RECORD: "never"
 
 jobs:
   macos:
@@ -19,7 +22,7 @@ jobs:
     runs-on: macos-13
     strategy:
       matrix:
-        swift-syntax-version: ['509.0.0..<510.0.0', '510.0.0..<511.0.0']
+        swift-syntax-version: ["509.0.0..<510.0.0", "510.0.0..<511.0.0"]
 
     steps:
       - uses: actions/checkout@v4

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "625ccca8570773dd84a34ee51a81aa2bc5a4f97a",
-        "version" : "1.16.0"
+        "revision" : "63d3b45dd249878a41c56274a748ca2c1c9c5230",
+        "version" : "1.17.1"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax",
       "state" : {
-        "revision" : "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
-        "version" : "510.0.1"
+        "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
+        "version" : "510.0.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.15.0"),
+    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.1"),
     //.conditionalPackage(url: "https://github.com/apple/swift-syntax", envVar: "SWIFT_SYNTAX_VERSION", default: "509.0.0..<510.0.0")
     //.conditionalPackage(url: "https://github.com/apple/swift-syntax", envVar: "SWIFT_SYNTAX_VERSION", default: "510.0.0..<511.0.0")
     .conditionalPackage(


### PR DESCRIPTION
- Support swift-snapshot-testing from 1.17.1
- Aligns vendored fork of swift-macro-testing with upstream 0.5.0
- Add support for SnapshotTesting's `Record` configuration
- Replace `isRecording` with `record` parameter in public API
- Refactor `assertMacro` to use `withSnapshotTesting`
- Update error handling to use `recordIssue` instead of `XCTFail`
- Update CI workflow to set SNAPSHOT_TESTING_RECORD environment variable
- Bump swift-snapshot-testing and swift-syntax dependencies