### PR TITLE
Support swift-syntax from 600.0.0-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,12 @@ jobs:
     runs-on: macos-13
     strategy:
       matrix:
-        swift-syntax-version: ["509.0.0..<510.0.0", "510.0.0..<511.0.0"]
+        swift-syntax-version:
+          [
+            "509.0.0..<510.0.0",
+            "510.0.0..<511.0.0",
+            "511.0.0..<601.0.0-prerelease",
+          ]
 
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,24 @@
+default: test
+
+test: test-swift
+
+test-swift:
+	swift test --parallel
+
+clean:
+	rm -rf .build
+
+test-swift-syntax-versions:
+	@for version in \
+		"509.0.0..<510.0.0" \
+		"510.0.0..<511.0.0" \
+		"511.0.0..<601.0.0-prerelease"; \
+	do \
+		echo "\n## Testing SwiftSyntax version $$version"; \
+		$(MAKE) clean; \
+		SWIFT_SYNTAX_VERSION="$$version" $(MAKE) test-swift || exit 1; \
+	done
+
 format:
 	swift format \
 		--ignore-unparsable-files \
@@ -5,4 +26,4 @@ format:
 		--recursive \
 		./Package.swift ./Sources ./Tests
 
-.PHONY: format
+.PHONY: default test test-swift clean test-swift-syntax-versions format

--- a/Package.swift
+++ b/Package.swift
@@ -26,10 +26,11 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.1"),
     //.conditionalPackage(url: "https://github.com/apple/swift-syntax", envVar: "SWIFT_SYNTAX_VERSION", default: "509.0.0..<510.0.0")
     //.conditionalPackage(url: "https://github.com/apple/swift-syntax", envVar: "SWIFT_SYNTAX_VERSION", default: "510.0.0..<511.0.0")
+    //.conditionalPackage(url: "https://github.com/apple/swift-syntax", envVar: "SWIFT_SYNTAX_VERSION", default: "511.0.0..<601.0.0-prerelease")
     .conditionalPackage(
       url: "https://github.com/apple/swift-syntax",
       envVar: "SWIFT_SYNTAX_VERSION",
-      default: "509.0.0..<511.0.0"
+      default: "509.0.0..<601.0.0-prerelease"
     ),
   ],
   targets: [

--- a/Sources/MacroTesting/AssertMacro.swift
+++ b/Sources/MacroTesting/AssertMacro.swift
@@ -246,11 +246,19 @@ public func assertMacro(
           origSourceFile: .init(moduleName: "TestModule", fullFilePath: "Test.swift")
         ]
       )
-      let expandedSourceFile = origSourceFile.expand(
-        macros: macros,
-        in: context,
-        indentationWidth: indentationWidth
-      )
+      #if canImport(SwiftSyntax600)
+        let expandedSourceFile = origSourceFile.expand(
+          macros: macros,
+          contextGenerator: { _ in context },
+          indentationWidth: indentationWidth
+        )
+      #else
+        let expandedSourceFile = origSourceFile.expand(
+          macros: macros,
+          in: context,
+          indentationWidth: indentationWidth
+        )
+      #endif
 
       var offset = 0
 

--- a/Sources/MacroTesting/Internal/AttributeRemover600.swift
+++ b/Sources/MacroTesting/Internal/AttributeRemover600.swift
@@ -1,0 +1,114 @@
+import SwiftSyntax
+
+public class AttributeRemover600: SyntaxRewriter {
+  let predicate: (AttributeSyntax) -> Bool
+
+  var triviaToAttachToNextToken: Trivia = Trivia()
+
+  /// Initializes an attribute remover with a given predicate to determine which attributes to remove.
+  ///
+  /// - Parameter predicate: A closure that determines whether a given `AttributeSyntax` should be removed.
+  ///   If this closure returns `true` for an attribute, that attribute will be removed.
+  public init(removingWhere predicate: @escaping (AttributeSyntax) -> Bool) {
+    self.predicate = predicate
+  }
+
+  public override func visit(_ node: AttributeListSyntax) -> AttributeListSyntax {
+    var filteredAttributes: [AttributeListSyntax.Element] = []
+    for case .attribute(let attribute) in node {
+      if self.predicate(attribute) {
+        var leadingTrivia = attribute.leadingTrivia
+
+        // Don't leave behind an empty line when the attribute being removed is on its own line,
+        // based on the following conditions:
+        //  - Leading trivia ends with a newline followed by arbitrary number of spaces or tabs
+        //  - All leading trivia pieces after the last newline are just whitespace, ensuring
+        //    there are no comments or other non-whitespace characters on the same line
+        //    preceding the attribute.
+        //  - There is no trailing trivia and the next token has leading trivia.
+        if let lastNewline = leadingTrivia.pieces.lastIndex(where: \.isNewline),
+          leadingTrivia.pieces[lastNewline...].allSatisfy(\.isWhitespace),
+          attribute.trailingTrivia.isEmpty,
+          let nextToken = attribute.nextToken(viewMode: .sourceAccurate),
+          !nextToken.leadingTrivia.isEmpty
+        {
+          leadingTrivia = Trivia(pieces: leadingTrivia.pieces[..<lastNewline])
+        }
+
+        // Drop any spaces or tabs from the trailing trivia because there’s no
+        // more attribute they need to separate.
+        let trailingTrivia = attribute.trailingTrivia.trimmingPrefix(while: \.isSpaceOrTab)
+        triviaToAttachToNextToken += leadingTrivia + trailingTrivia
+
+        // If the attribute is not separated from the previous attribute by trivia, as in
+        // `@First@Second var x: Int` (yes, that's valid Swift), removing the `@Second`
+        // attribute and dropping all its trivia would cause `@First` and `var` to join
+        // without any trivia in between, which is invalid. In such cases, the trailing trivia
+        // of the attribute is significant and must be retained.
+        if triviaToAttachToNextToken.isEmpty,
+          let previousToken = attribute.previousToken(viewMode: .sourceAccurate),
+          previousToken.trailingTrivia.isEmpty
+        {
+          triviaToAttachToNextToken = attribute.trailingTrivia
+        }
+      } else {
+        filteredAttributes.append(.attribute(prependAndClearAccumulatedTrivia(to: attribute)))
+      }
+    }
+
+    // Ensure that any horizontal whitespace trailing the attributes list is trimmed if the next
+    // token starts a new line.
+    if let nextToken = node.nextToken(viewMode: .sourceAccurate),
+      nextToken.leadingTrivia.startsWithNewline
+    {
+      if !triviaToAttachToNextToken.isEmpty {
+        triviaToAttachToNextToken = triviaToAttachToNextToken.trimmingSuffix(while: \.isSpaceOrTab)
+      } else if let lastAttribute = filteredAttributes.last {
+        filteredAttributes[filteredAttributes.count - 1].trailingTrivia = lastAttribute
+          .trailingTrivia
+          .trimmingSuffix(while: \.isSpaceOrTab)
+      }
+    }
+    return AttributeListSyntax(filteredAttributes)
+  }
+
+  public override func visit(_ token: TokenSyntax) -> TokenSyntax {
+    return prependAndClearAccumulatedTrivia(to: token)
+  }
+
+  /// Prepends the accumulated trivia to the given node's leading trivia.
+  ///
+  /// To preserve correct formatting after attribute removal, this function reassigns
+  /// significant trivia accumulated from removed attributes to the provided subsequent node.
+  /// Once attached, the accumulated trivia is cleared.
+  ///
+  /// - Parameter node: The syntax node receiving the accumulated trivia.
+  /// - Returns: The modified syntax node with the prepended trivia.
+  private func prependAndClearAccumulatedTrivia<T: SyntaxProtocol>(to syntaxNode: T) -> T {
+    defer { triviaToAttachToNextToken = Trivia() }
+    return syntaxNode.with(\.leadingTrivia, triviaToAttachToNextToken + syntaxNode.leadingTrivia)
+  }
+}
+
+extension Trivia {
+  fileprivate func trimmingPrefix(
+    while predicate: (TriviaPiece) -> Bool
+  ) -> Trivia {
+    Trivia(pieces: self.drop(while: predicate))
+  }
+
+  fileprivate func trimmingSuffix(
+    while predicate: (TriviaPiece) -> Bool
+  ) -> Trivia {
+    Trivia(
+      pieces: self[...]
+        .reversed()
+        .drop(while: predicate)
+        .reversed()
+    )
+  }
+
+  fileprivate var startsWithNewline: Bool {
+    self.first?.isNewline ?? false
+  }
+}

--- a/Sources/MacroTesting/MacrosTestTrait.swift
+++ b/Sources/MacroTesting/MacrosTestTrait.swift
@@ -1,0 +1,51 @@
+#if canImport(Testing)
+  import SnapshotTesting
+  import SwiftSyntax
+  import SwiftSyntaxMacros
+  @_spi(Experimental) import Testing
+
+  @_spi(Experimental)
+  extension Trait where Self == _MacrosTestTrait {
+    /// Configure snapshot testing in a suite or test.
+    ///
+    /// - Parameters:
+    ///   - record: The record mode of the test.
+    ///   - diffTool: The diff tool to use in failure messages.
+    public static func macros(
+      indentationWidth: Trivia? = nil,
+      record: SnapshotTestingConfiguration.Record? = nil,
+      macros: [String: Macro.Type]? = nil
+    ) -> Self {
+      _MacrosTestTrait(
+        configuration: MacroTestingConfiguration(
+          indentationWidth: indentationWidth,
+          macros: macros
+        ),
+        record: record
+      )
+    }
+  }
+
+  /// A type representing the configuration of snapshot testing.
+  @_spi(Experimental)
+  public struct _MacrosTestTrait: CustomExecutionTrait, SuiteTrait, TestTrait {
+    public let isRecursive = true
+    let configuration: MacroTestingConfiguration
+    let record: SnapshotTestingConfiguration.Record?
+
+    public func execute(
+      _ function: @escaping () async throws -> Void,
+      for test: Test,
+      testCase: Test.Case?
+    ) async throws {
+      try await withMacroTesting(
+        indentationWidth: configuration.indentationWidth,
+        macros: configuration.macros
+      ) {
+        try await withSnapshotTesting(record: record) {
+          try await function()
+        }
+      }
+    }
+  }
+#endif

--- a/Sources/MemberwiseInitMacros/Macros/Support/ExprTypeInference.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/ExprTypeInference.swift
@@ -1,5 +1,10 @@
 import SwiftOperators
-import SwiftSyntax
+
+#if canImport(SwiftSyntax600)
+  @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+#else
+  import SwiftSyntax
+#endif
 
 // Potential future enhancements:
 // - .ternaryExpr having "then" and "else" expressions as inferrable types
@@ -261,12 +266,30 @@ extension ExprSyntax {
         return nil
     #endif
 
+    #if !canImport(SwiftSyntax600)
+      case .canImportExpr, .canImportVersionInfo:
+        return nil
+    #endif
+
+    #if canImport(SwiftSyntax600)
+      case ._canImportExpr,
+        ._canImportVersionInfo,
+        .doExpr,
+        .lifetimeSpecifierArgumentList,
+        .lifetimeSpecifierArgument,
+        .lifetimeTypeSpecifier,
+        .simpleTypeSpecifier,
+        .throwsClause,
+        .typeSpecifierList:
+        return nil
+    #endif
+
     case .token, .accessorBlock, .accessorDeclList, .accessorDecl, .accessorEffectSpecifiers,
       .accessorParameters, .actorDecl, .arrayElementList, .arrayElement, .arrayType, .arrowExpr,
       .assignmentExpr, .associatedTypeDecl, .attributeList, .attribute, .attributedType,
       .availabilityArgumentList, .availabilityArgument, .availabilityCondition,
       .availabilityLabeledArgument, .awaitExpr, .backDeployedAttributeArguments,
-      .binaryOperatorExpr, .borrowExpr, .breakStmt, .canImportExpr, .canImportVersionInfo,
+      .binaryOperatorExpr, .borrowExpr, .breakStmt,
       .catchClauseList, .catchClause, .catchItemList, .catchItem, .classDecl, .classRestrictionType,
       .closureCaptureClause, .closureCaptureList, .closureCaptureSpecifier, .closureCapture,
       .closureExpr, .closureParameterClause, .closureParameterList, .closureParameter,

--- a/Tests/MacroTestingTests/AddAsyncTests.swift
+++ b/Tests/MacroTestingTests/AddAsyncTests.swift
@@ -9,60 +9,119 @@ final class AddAsyncMacroTests: BaseTestCase {
   }
 
   func testExpansionTransformsFunctionWithResultCompletionToAsyncThrows() {
-    assertMacro {
-      #"""
-      @AddAsync
-      func c(a: Int, for b: String, _ value: Double, completionBlock: @escaping (Result<String, Error>) -> Void) -> Void {
-        completionBlock(.success("a: \(a), b: \(b), value: \(value)"))
-      }
-      """#
-    } expansion: {
-      #"""
-      func c(a: Int, for b: String, _ value: Double, completionBlock: @escaping (Result<String, Error>) -> Void) -> Void {
-        completionBlock(.success("a: \(a), b: \(b), value: \(value)"))
-      }
+    #if canImport(SwiftSyntax600)
+      assertMacro {
+        #"""
+        @AddAsync
+        func c(a: Int, for b: String, _ value: Double, completionBlock: @escaping (Result<String, Error>) -> Void) -> Void {
+          completionBlock(.success("a: \(a), b: \(b), value: \(value)"))
+        }
+        """#
+      } expansion: {
+        #"""
+        func c(a: Int, for b: String, _ value: Double, completionBlock: @escaping (Result<String, Error>) -> Void) -> Void {
+          completionBlock(.success("a: \(a), b: \(b), value: \(value)"))
+        }
 
-      func c(a: Int, for b: String, _ value: Double) async throws -> String {
-        try await withCheckedThrowingContinuation { continuation in
-          c(a: a, for: b, value) { returnValue in
+        func c(a: Int, for b: String, _ value: Double) async throws -> String {
+          try await withCheckedThrowingContinuation { continuation in
+            c(a: a, for: b, value) { returnValue in
 
-            switch returnValue {
-            case .success(let value):
-              continuation.resume(returning: value)
-            case .failure(let error):
-              continuation.resume(throwing: error)
+              switch returnValue {
+              case .success(let value):
+                continuation.resume(returning: value)
+              case .failure(let error):
+                continuation.resume(throwing: error)
+              }
+            }
+          }
+
+        }
+        """#
+      }
+    #else
+      assertMacro {
+        #"""
+        @AddAsync
+        func c(a: Int, for b: String, _ value: Double, completionBlock: @escaping (Result<String, Error>) -> Void) -> Void {
+          completionBlock(.success("a: \(a), b: \(b), value: \(value)"))
+        }
+        """#
+      } expansion: {
+        #"""
+        func c(a: Int, for b: String, _ value: Double, completionBlock: @escaping (Result<String, Error>) -> Void) -> Void {
+          completionBlock(.success("a: \(a), b: \(b), value: \(value)"))
+        }
+
+        func c(a: Int, for b: String, _ value: Double) async throws -> String {
+          try await withCheckedThrowingContinuation { continuation in
+            c(a: a, for: b, value) { returnValue in
+
+              switch returnValue {
+              case .success(let value):
+                continuation.resume(returning: value)
+              case .failure(let error):
+                continuation.resume(throwing: error)
+              }
             }
           }
         }
+        """#
       }
-      """#
-    }
+    #endif
   }
 
   func testExpansionTransformsFunctionWithBoolCompletionToAsync() {
-    assertMacro {
-      """
-      @AddAsync
-      func d(a: Int, for b: String, _ value: Double, completionBlock: @escaping (Bool) -> Void) -> Void {
-        completionBlock(true)
-      }
-      """
-    } expansion: {
-      """
-      func d(a: Int, for b: String, _ value: Double, completionBlock: @escaping (Bool) -> Void) -> Void {
-        completionBlock(true)
-      }
+    #if canImport(SwiftSyntax600)
+      assertMacro {
+        """
+        @AddAsync
+        func d(a: Int, for b: String, _ value: Double, completionBlock: @escaping (Bool) -> Void) -> Void {
+          completionBlock(true)
+        }
+        """
+      } expansion: {
+        """
+        func d(a: Int, for b: String, _ value: Double, completionBlock: @escaping (Bool) -> Void) -> Void {
+          completionBlock(true)
+        }
 
-      func d(a: Int, for b: String, _ value: Double) async -> Bool {
-        await withCheckedContinuation { continuation in
-          d(a: a, for: b, value) { returnValue in
+        func d(a: Int, for b: String, _ value: Double) async -> Bool {
+          await withCheckedContinuation { continuation in
+            d(a: a, for: b, value) { returnValue in
 
-            continuation.resume(returning: returnValue)
+              continuation.resume(returning: returnValue)
+            }
+          }
+
+        }
+        """
+      }
+    #else
+      assertMacro {
+        """
+        @AddAsync
+        func d(a: Int, for b: String, _ value: Double, completionBlock: @escaping (Bool) -> Void) -> Void {
+          completionBlock(true)
+        }
+        """
+      } expansion: {
+        """
+        func d(a: Int, for b: String, _ value: Double, completionBlock: @escaping (Bool) -> Void) -> Void {
+          completionBlock(true)
+        }
+
+        func d(a: Int, for b: String, _ value: Double) async -> Bool {
+          await withCheckedContinuation { continuation in
+            d(a: a, for: b, value) { returnValue in
+
+              continuation.resume(returning: returnValue)
+            }
           }
         }
+        """
       }
-      """
-    }
+    #endif
   }
 
   func testExpansionOnStoredPropertyEmitsError() {

--- a/Tests/MacroTestingTests/AddCompletionHandlerTests.swift
+++ b/Tests/MacroTestingTests/AddCompletionHandlerTests.swift
@@ -9,26 +9,50 @@ final class AddCompletionHandlerTests: BaseTestCase {
   }
 
   func testExpansionTransformsAsyncFunctionToCompletion() {
-    assertMacro {
-      """
-      @AddCompletionHandler
-      func f(a: Int, for b: String, _ value: Double) async -> String {
-        return b
-      }
-      """
-    } expansion: {
-      """
-      func f(a: Int, for b: String, _ value: Double) async -> String {
-        return b
-      }
-
-      func f(a: Int, for b: String, _ value: Double, completionHandler: @escaping (String) -> Void) {
-        Task {
-          completionHandler(await f(a: a, for: b, value))
+    #if canImport(SwiftSyntax600)
+      assertMacro {
+        """
+        @AddCompletionHandler
+        func f(a: Int, for b: String, _ value: Double) async -> String {
+          return b
         }
+        """
+      } expansion: {
+        """
+        func f(a: Int, for b: String, _ value: Double) async -> String {
+          return b
+        }
+
+        func f(a: Int, for b: String, _ value: Double, completionHandler: @escaping (String) -> Void) {
+          Task {
+            completionHandler(await f(a: a, for: b, value))
+          }
+
+        }
+        """
       }
-      """
-    }
+    #else
+      assertMacro {
+        """
+        @AddCompletionHandler
+        func f(a: Int, for b: String, _ value: Double) async -> String {
+          return b
+        }
+        """
+      } expansion: {
+        """
+        func f(a: Int, for b: String, _ value: Double) async -> String {
+          return b
+        }
+
+        func f(a: Int, for b: String, _ value: Double, completionHandler: @escaping (String) -> Void) {
+          Task {
+            completionHandler(await f(a: a, for: b, value))
+          }
+        }
+        """
+      }
+    #endif
   }
 
   func testExpansionOnStoredPropertyEmitsError() {

--- a/Tests/MacroTestingTests/BaseTestCase.swift
+++ b/Tests/MacroTestingTests/BaseTestCase.swift
@@ -2,9 +2,11 @@ import MacroTesting
 import XCTest
 
 class BaseTestCase: XCTestCase {
-  // override func invokeTest() {
-  //   withMacroTesting(isRecording: true) {
-  //     super.invokeTest()
-  //   }
-  // }
+  override func invokeTest() {
+    withMacroTesting(
+      record: .missing
+    ) {
+      super.invokeTest()
+    }
+  }
 }

--- a/Tests/MacroTestingTests/DefaultFatalErrorImplementationMacroTests.swift
+++ b/Tests/MacroTestingTests/DefaultFatalErrorImplementationMacroTests.swift
@@ -1,0 +1,65 @@
+import MacroTesting
+import XCTest
+
+final class DefaultFatalErrorImplementationMacroTests: BaseTestCase {
+  override func invokeTest() {
+    withMacroTesting(
+      macros: ["defaultFatalErrorImplementation": DefaultFatalErrorImplementationMacro.self]
+    ) {
+      super.invokeTest()
+    }
+  }
+
+  func testExpansionWhenAttachedToProtocolExpandsCorrectly() {
+    assertMacro {
+      """
+      @defaultFatalErrorImplementation
+      protocol MyProtocol {
+        func foo()
+        func bar() -> Int
+      }
+      """
+    } expansion: {
+      """
+      protocol MyProtocol {
+        func foo()
+        func bar() -> Int
+      }
+
+      extension MyProtocol {
+        func foo() {
+          fatalError("whoops 😅")
+        }
+        func bar() -> Int {
+          fatalError("whoops 😅")
+        }
+      }
+      """
+    }
+  }
+
+  func testExpansionWhenNotAttachedToProtocolProducesDiagnostic() {
+    assertMacro {
+      """
+      @defaultFatalErrorImplementation
+      class MyClass {}
+      """
+    } diagnostics: {
+      """
+      @defaultFatalErrorImplementation
+      ┬───────────────────────────────
+      ╰─ 🛑 Macro `defaultFatalErrorImplementation` can only be applied to a protocol
+      class MyClass {}
+      """
+    }
+  }
+
+  func testExpansionWhenAttachedToEmptyProtocolDoesNotAddExtension() {
+    assertMacro {
+      """
+      @defaultFatalErrorImplementation
+      protocol EmptyProtocol {}
+      """
+    }
+  }
+}

--- a/Tests/MacroTestingTests/MacroExamples/AddAsyncMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/AddAsyncMacro.swift
@@ -30,7 +30,7 @@ public struct AddAsyncMacro: PeerMacro {
   ) throws -> [DeclSyntax] {
 
     // Only on functions at the moment.
-    guard let funcDecl = declaration.as(FunctionDeclSyntax.self) else {
+    guard var funcDecl = declaration.as(FunctionDeclSyntax.self) else {
       throw CustomError.message("@addAsync only works on functions")
     }
 
@@ -42,9 +42,7 @@ public struct AddAsyncMacro: PeerMacro {
     }
 
     // This only makes sense void functions
-    if funcDecl.signature.returnClause?.type.with(\.leadingTrivia, []).with(\.trailingTrivia, [])
-      .description != "Void"
-    {
+    if funcDecl.signature.returnClause?.type.as(IdentifierTypeSyntax.self)?.name.text != "Void" {
       throw CustomError.message(
         "@addAsync requires an function that returns void"
       )
@@ -63,9 +61,9 @@ public struct AddAsyncMacro: PeerMacro {
     }
 
     // Completion handler needs to return Void
-    if completionHandlerParameter.returnClause.type.with(\.leadingTrivia, []).with(
-      \.trailingTrivia, []
-    ).description != "Void" {
+    if completionHandlerParameter.returnClause.type.as(IdentifierTypeSyntax.self)?.name.text
+      != "Void"
+    {
       throw CustomError.message(
         "@addAsync requires an function that has a completion handler that returns Void"
       )
@@ -82,10 +80,11 @@ public struct AddAsyncMacro: PeerMacro {
     // Remove completionHandler and comma from the previous parameter
     var newParameterList = funcDecl.signature.parameterClause.parameters
     newParameterList.removeLast()
-    let newParameterListLastParameter = newParameterList.last!
+    var newParameterListLastParameter = newParameterList.last!
     newParameterList.removeLast()
-    newParameterList.append(
-      newParameterListLastParameter.with(\.trailingTrivia, []).with(\.trailingComma, nil))
+    newParameterListLastParameter.trailingTrivia = []
+    newParameterListLastParameter.trailingComma = nil
+    newParameterList.append(newParameterListLastParameter)
 
     // Drop the @addAsync attribute from the new declaration.
     let newAttributeList = funcDecl.attributes.filter {
@@ -132,44 +131,37 @@ public struct AddAsyncMacro: PeerMacro {
 
       """
 
-    let newFunc =
-      funcDecl
-      .with(
-        \.signature,
-        funcDecl.signature
-          .with(
-            \.effectSpecifiers,
-            FunctionEffectSpecifiersSyntax(
-              leadingTrivia: .space,
-              asyncSpecifier: .keyword(.async),
-              throwsSpecifier: isResultReturn ? .keyword(.throws) : nil
-            )  // add async
-          )
-          .with(
-            \.returnClause,
-            successReturnType != nil
-              ? ReturnClauseSyntax(
-                leadingTrivia: .space, type: successReturnType!.with(\.leadingTrivia, .space)) : nil
-          )  // add result type
-          .with(
-            \.parameterClause,
-            funcDecl.signature.parameterClause.with(\.parameters, newParameterList)  // drop completion handler
-              .with(\.trailingTrivia, [])
-          )
-      )
-      .with(
-        \.body,
-        CodeBlockSyntax(
-          leftBrace: .leftBraceToken(leadingTrivia: .space),
-          statements: CodeBlockItemListSyntax(
-            [CodeBlockItemSyntax(item: .expr(newBody))]
-          ),
-          rightBrace: .rightBraceToken(leadingTrivia: .newline)
-        )
-      )
-      .with(\.attributes, newAttributeList)
-      .with(\.leadingTrivia, .newlines(2))
+    // add async
+    funcDecl.signature.effectSpecifiers = FunctionEffectSpecifiersSyntax(
+      leadingTrivia: .space,
+      asyncSpecifier: .keyword(.async),
+      throwsSpecifier: isResultReturn ? .keyword(.throws) : nil
+    )
 
-    return [DeclSyntax(newFunc)]
+    // add result type
+    if let successReturnType {
+      funcDecl.signature.returnClause = ReturnClauseSyntax(
+        leadingTrivia: .space, type: successReturnType.with(\.leadingTrivia, .space))
+    } else {
+      funcDecl.signature.returnClause = nil
+    }
+
+    // drop completion handler
+    funcDecl.signature.parameterClause.parameters = newParameterList
+    funcDecl.signature.parameterClause.trailingTrivia = []
+
+    funcDecl.body = CodeBlockSyntax(
+      leftBrace: .leftBraceToken(leadingTrivia: .space),
+      statements: CodeBlockItemListSyntax(
+        [CodeBlockItemSyntax(item: .expr(newBody))]
+      ),
+      rightBrace: .rightBraceToken(leadingTrivia: .newline)
+    )
+
+    funcDecl.attributes = newAttributeList
+
+    funcDecl.leadingTrivia = .newlines(2)
+
+    return [DeclSyntax(funcDecl)]
   }
 }

--- a/Tests/MacroTestingTests/MacroExamples/AddBlocker.swift
+++ b/Tests/MacroTestingTests/MacroExamples/AddBlocker.swift
@@ -27,7 +27,7 @@ public struct AddBlocker: ExpressionMacro {
       _ node: InfixOperatorExprSyntax
     ) -> ExprSyntax {
       // Identify any infix operator + in the tree.
-      if let binOp = node.operator.as(BinaryOperatorExprSyntax.self) {
+      if var binOp = node.operator.as(BinaryOperatorExprSyntax.self) {
         if binOp.operator.text == "+" {
           // Form the warning
           let messageID = MessageID(domain: "silly", id: "addblock")
@@ -72,17 +72,9 @@ public struct AddBlocker: ExpressionMacro {
             )
           )
 
-          return ExprSyntax(
-            node.with(
-              \.operator,
-              ExprSyntax(
-                binOp.with(
-                  \.operator,
-                  binOp.operator.with(\.tokenKind, .binaryOperator("-"))
-                )
-              )
-            )
-          )
+          binOp.operator.tokenKind = .binaryOperator("-")
+
+          return ExprSyntax(node.with(\.operator, ExprSyntax(binOp)))
         }
       }
 

--- a/Tests/MacroTestingTests/MacroExamples/AddCompletionHandlerMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/AddCompletionHandlerMacro.swift
@@ -25,20 +25,22 @@ public struct AddCompletionHandlerMacro: PeerMacro {
   ) throws -> [DeclSyntax] {
     // Only on functions at the moment. We could handle initializers as well
     // with a bit of work.
-    guard let funcDecl = declaration.as(FunctionDeclSyntax.self) else {
+    guard var funcDecl = declaration.as(FunctionDeclSyntax.self) else {
       throw CustomError.message("@addCompletionHandler only works on functions")
     }
 
     // This only makes sense for async functions.
     if funcDecl.signature.effectSpecifiers?.asyncSpecifier == nil {
-      let newEffects: FunctionEffectSpecifiersSyntax
+      var newEffects: FunctionEffectSpecifiersSyntax
       if let existingEffects = funcDecl.signature.effectSpecifiers {
-        newEffects = existingEffects.with(\.asyncSpecifier, .keyword(.async))
+        newEffects = existingEffects
+        newEffects.asyncSpecifier = .keyword(.async)
       } else {
         newEffects = FunctionEffectSpecifiersSyntax(asyncSpecifier: .keyword(.async))
       }
 
-      let newSignature = funcDecl.signature.with(\.effectSpecifiers, newEffects)
+      var newSignature = funcDecl.signature
+      newSignature.effectSpecifiers = newEffects
       let messageID = MessageID(domain: "MacroExamples", id: "MissingAsync")
 
       let diag = Diagnostic(
@@ -73,8 +75,9 @@ public struct AddCompletionHandlerMacro: PeerMacro {
     }
 
     // Form the completion handler parameter.
-    let resultType: TypeSyntax? = funcDecl.signature.returnClause?.type.with(\.leadingTrivia, [])
-      .with(\.trailingTrivia, [])
+    var resultType = funcDecl.signature.returnClause?.type
+    resultType?.leadingTrivia = []
+    resultType?.trailingTrivia = []
 
     let completionHandlerParam =
       FunctionParameterSyntax(
@@ -86,14 +89,12 @@ public struct AddCompletionHandlerMacro: PeerMacro {
     // Add the completion handler parameter to the parameter list.
     let parameterList = funcDecl.signature.parameterClause.parameters
     var newParameterList = parameterList
-    if let lastParam = parameterList.last {
+    if var lastParam = parameterList.last {
       // We need to add a trailing comma to the preceding list.
       newParameterList.removeLast()
+      lastParam.trailingComma = .commaToken(trailingTrivia: .space)
       newParameterList += [
-        lastParam.with(
-          \.trailingComma,
-          .commaToken(trailingTrivia: .space)
-        ),
+        lastParam,
         completionHandlerParam,
       ]
     } else {
@@ -137,35 +138,28 @@ public struct AddCompletionHandlerMacro: PeerMacro {
       return attributeType.name.text != nodeType.name.text
     }
 
-    let newFunc =
-      funcDecl
-      .with(
-        \.signature,
-        funcDecl.signature
-          .with(
-            \.effectSpecifiers,
-            funcDecl.signature.effectSpecifiers?.with(\.asyncSpecifier, nil)  // drop async
-          )
-          .with(\.returnClause, nil)  // drop result type
-          .with(
-            \.parameterClause,  // add completion handler parameter
-            funcDecl.signature.parameterClause.with(\.parameters, newParameterList)
-              .with(\.trailingTrivia, [])
-          )
-      )
-      .with(
-        \.body,
-        CodeBlockSyntax(
-          leftBrace: .leftBraceToken(leadingTrivia: .space),
-          statements: CodeBlockItemListSyntax(
-            [CodeBlockItemSyntax(item: .expr(newBody))]
-          ),
-          rightBrace: .rightBraceToken(leadingTrivia: .newline)
-        )
-      )
-      .with(\.attributes, newAttributeList)
-      .with(\.leadingTrivia, .newlines(2))
+    // drop async
+    funcDecl.signature.effectSpecifiers?.asyncSpecifier = nil
 
-    return [DeclSyntax(newFunc)]
+    // drop result type
+    funcDecl.signature.returnClause = nil
+
+    // add completion handler parameter
+    funcDecl.signature.parameterClause.parameters = newParameterList
+    funcDecl.signature.parameterClause.trailingTrivia = []
+
+    funcDecl.body = CodeBlockSyntax(
+      leftBrace: .leftBraceToken(leadingTrivia: .space),
+      statements: CodeBlockItemListSyntax(
+        [CodeBlockItemSyntax(item: .expr(newBody))]
+      ),
+      rightBrace: .rightBraceToken(leadingTrivia: .newline)
+    )
+
+    funcDecl.attributes = newAttributeList
+
+    funcDecl.leadingTrivia = .newlines(2)
+
+    return [DeclSyntax(funcDecl)]
   }
 }

--- a/Tests/MacroTestingTests/MacroExamples/DefaultFatalErrorImplementationMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/DefaultFatalErrorImplementationMacro.swift
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+/// Provides default `fatalError` implementations for protocol methods.
+///
+/// This macro generates extensions that add default `fatalError` implementations
+/// for each method in the protocol it is attached to.
+public enum DefaultFatalErrorImplementationMacro: ExtensionMacro {
+
+  /// Unique identifier for messages related to this macro.
+  private static let messageID = MessageID(
+    domain: "MacroExamples", id: "ProtocolDefaultImplementation")
+
+  /// Generates extension for the protocol to which this macro is attached.
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+
+    // Validate that the macro is being applied to a protocol declaration
+    guard let protocolDecl = declaration.as(ProtocolDeclSyntax.self) else {
+      throw SimpleDiagnosticMessage(
+        message: "Macro `defaultFatalErrorImplementation` can only be applied to a protocol",
+        diagnosticID: messageID,
+        severity: .error
+      )
+    }
+
+    // Extract all the methods from the protocol and assign default implementations
+    let methods = protocolDecl.memberBlock.members
+      .map(\.decl)
+      .compactMap { declaration -> FunctionDeclSyntax? in
+        guard var function = declaration.as(FunctionDeclSyntax.self) else {
+          return nil
+        }
+        function.body = CodeBlockSyntax {
+          ExprSyntax(#"fatalError("whoops 😅")"#)
+        }
+        return function
+      }
+
+    // Don't generate an extension if there are no methods
+    if methods.isEmpty {
+      return []
+    }
+
+    // Generate the extension containing the default implementations
+    let extensionDecl = ExtensionDeclSyntax(extendedType: type) {
+      for method in methods {
+        MemberBlockItemSyntax(decl: method)
+      }
+    }
+
+    return [extensionDecl]
+  }
+}

--- a/Tests/MacroTestingTests/MacroExamples/DictionaryIndirectionMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/DictionaryIndirectionMacro.swift
@@ -21,10 +21,7 @@ extension DictionaryStorageMacro: MemberMacro {
     providingMembersOf declaration: some DeclGroupSyntax,
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
-    let storage: DeclSyntax = "var _storage: [String: Any] = [:]"
-    return [
-      storage.with(\.leadingTrivia, [.newlines(1), .spaces(2)])
-    ]
+    return ["\n  var _storage: [String: Any] = [:]"]
   }
 }
 
@@ -43,11 +40,11 @@ extension DictionaryStorageMacro: MemberAttributeMacro {
 
     return [
       AttributeSyntax(
+        leadingTrivia: [.newlines(1), .spaces(2)],
         attributeName: IdentifierTypeSyntax(
           name: .identifier("DictionaryStorageProperty")
         )
       )
-      .with(\.leadingTrivia, [.newlines(1), .spaces(2)])
     ]
   }
 }

--- a/Tests/MacroTestingTests/MacroExamples/FontLiteralMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/FontLiteralMacro.swift
@@ -35,14 +35,12 @@ private func replaceFirstLabel(
   of tuple: LabeledExprListSyntax,
   with newLabel: String
 ) -> LabeledExprListSyntax {
-  guard let firstElement = tuple.first else {
+  if tuple.isEmpty {
     return tuple
   }
 
   var tuple = tuple
-  tuple[tuple.startIndex] =
-    firstElement
-    .with(\.label, .identifier(newLabel))
-    .with(\.colon, .colonToken())
+  tuple[tuple.startIndex].label = .identifier(newLabel)
+  tuple[tuple.startIndex].colon = .colonToken()
   return tuple
 }

--- a/Tests/MacroTestingTests/MacroExamples/ObservableMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/ObservableMacro.swift
@@ -1,0 +1,173 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+extension DeclSyntaxProtocol {
+  fileprivate var isObservableStoredProperty: Bool {
+    if let property = self.as(VariableDeclSyntax.self),
+      let binding = property.bindings.first,
+      let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier,
+      identifier.text != "_registrar", identifier.text != "_storage",
+      binding.accessorBlock == nil
+    {
+      return true
+    }
+
+    return false
+  }
+}
+
+public struct ObservableMacro: MemberMacro, MemberAttributeMacro {
+
+  // MARK: - MemberMacro
+
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard let identified = declaration.asProtocol(NamedDeclSyntax.self) else {
+      return []
+    }
+
+    let parentName = identified.name
+
+    let registrar: DeclSyntax =
+      """
+      let _registrar = ObservationRegistrar<\(parentName)>()
+      """
+
+    let addObserver: DeclSyntax =
+      """
+      public nonisolated func addObserver(_ observer: some Observer<\(parentName)>) {
+        _registrar.addObserver(observer)
+      }
+      """
+
+    let removeObserver: DeclSyntax =
+      """
+      public nonisolated func removeObserver(_ observer: some Observer<\(parentName)>) {
+        _registrar.removeObserver(observer)
+      }
+      """
+
+    let withTransaction: DeclSyntax =
+      """
+      private func withTransaction<T>(_ apply: () throws -> T) rethrows -> T {
+        _registrar.beginAccess()
+        defer { _registrar.endAccess() }
+        return try apply()
+      }
+      """
+
+    let memberList = declaration.memberBlock.members.filter {
+      $0.decl.isObservableStoredProperty
+    }
+
+    let storageStruct: DeclSyntax =
+      """
+      private struct Storage {
+      \(memberList)
+      }
+      """
+
+    let storage: DeclSyntax =
+      """
+      private var _storage = Storage()
+      """
+
+    return [
+      registrar,
+      addObserver,
+      removeObserver,
+      withTransaction,
+      storageStruct,
+      storage,
+    ]
+  }
+
+  // MARK: - MemberAttributeMacro
+
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingAttributesFor member: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [SwiftSyntax.AttributeSyntax] {
+    guard member.isObservableStoredProperty else {
+      return []
+    }
+
+    return [
+      AttributeSyntax(
+        attributeName: IdentifierTypeSyntax(
+          name: .identifier("ObservableProperty")
+        )
+      )
+    ]
+  }
+
+}
+
+extension ObservableMacro: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    [try ExtensionDeclSyntax("extension \(type): Observable {}")]
+  }
+}
+
+public struct ObservablePropertyMacro: AccessorMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingAccessorsOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [AccessorDeclSyntax] {
+    guard let property = declaration.as(VariableDeclSyntax.self),
+      let binding = property.bindings.first,
+      let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier,
+      binding.accessorBlock == nil
+    else {
+      return []
+    }
+
+    let getAccessor: AccessorDeclSyntax =
+      """
+      get {
+        _registrar.beginAccess(\\.\(identifier))
+        defer { _registrar.endAccess() }
+        return _storage.\(identifier)
+      }
+      """
+
+    let setAccessor: AccessorDeclSyntax =
+      """
+      set {
+        _registrar.beginAccess(\\.\(identifier))
+        _registrar.register(observable: self, willSet: \\.\(identifier), to: newValue)
+        defer {
+          _registrar.register(observable: self, didSet: \\.\(identifier))
+          _registrar.endAccess()
+        }
+        _storage.\(identifier) = newValue
+      }
+      """
+
+    return [getAccessor, setAccessor]
+  }
+}

--- a/Tests/MacroTestingTests/MacroExamples/OptionSetMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/OptionSetMacro.swift
@@ -155,9 +155,8 @@ extension OptionSetMacro: ExtensionMacro {
 
     // If there is an explicit conformance to OptionSet already, don't add one.
     if let inheritedTypes = structDecl.inheritanceClause?.inheritedTypes,
-      inheritedTypes.contains(
-        where: { inherited in inherited.type.trimmedDescription == "OptionSet" }
-      )
+      inheritedTypes.contains(where: { inherited in inherited.type.trimmedDescription == "OptionSet"
+      })
     {
       return []
     }

--- a/Tests/MacroTestingTests/MacroExamples/URLMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/URLMacro.swift
@@ -29,7 +29,7 @@ public enum URLMacro: ExpressionMacro {
       throw CustomError.message("#URL requires a static string literal")
     }
 
-    guard let _ = URL(string: literalSegment.content.text) else {
+    guard URL(string: literalSegment.content.text) != nil else {
       throw CustomError.message("malformed url: \(argument)")
     }
 

--- a/Tests/MacroTestingTests/MacroExamples/WrapStoredPropertiesMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/WrapStoredPropertiesMacro.swift
@@ -49,11 +49,11 @@ public struct WrapStoredPropertiesMacro: MemberAttributeMacro {
 
     return [
       AttributeSyntax(
+        leadingTrivia: [.newlines(1), .spaces(2)],
         attributeName: IdentifierTypeSyntax(
           name: .identifier(wrapperName.content.text)
         )
       )
-      .with(\.leadingTrivia, [.newlines(1), .spaces(2)])
     ]
   }
 }

--- a/Tests/MacroTestingTests/ObservableMacroTests.swift
+++ b/Tests/MacroTestingTests/ObservableMacroTests.swift
@@ -1,0 +1,249 @@
+import MacroTesting
+import XCTest
+
+final class ObservableMacroTests: XCTestCase {
+  override func invokeTest() {
+    withMacroTesting(
+      macros: [
+        "Observable": ObservableMacro.self,
+        "ObservableProperty": ObservablePropertyMacro.self,
+      ]
+    ) {
+      super.invokeTest()
+    }
+  }
+
+  func testExpansion() {
+    #if !canImport(SwiftSyntax510)
+      assertMacro {
+        """
+        @Observable
+        final class Dog {
+          var name: String?
+          var treat: Treat?
+
+          var isHappy: Bool = true
+
+          init() {}
+
+          func bark() {
+            print("bork bork")
+          }
+        }
+        """
+      } expansion: {
+        #"""
+        final class Dog {
+          var name: String? {
+            get {
+              _registrar.beginAccess(\.name)
+              defer {
+                _registrar.endAccess()
+              }
+              return _storage.name
+            }
+            set {
+              _registrar.beginAccess(\.name)
+              _registrar.register(observable: self, willSet: \.name, to: newValue)
+              defer {
+                _registrar.register(observable: self, didSet: \.name)
+                _registrar.endAccess()
+              }
+              _storage.name = newValue
+            }
+          }
+          var treat: Treat? {
+            get {
+              _registrar.beginAccess(\.treat)
+              defer {
+                _registrar.endAccess()
+              }
+              return _storage.treat
+            }
+            set {
+              _registrar.beginAccess(\.treat)
+              _registrar.register(observable: self, willSet: \.treat, to: newValue)
+              defer {
+                _registrar.register(observable: self, didSet: \.treat)
+                _registrar.endAccess()
+              }
+              _storage.treat = newValue
+            }
+          }
+
+          var isHappy: Bool = true {
+            get {
+              _registrar.beginAccess(\.isHappy)
+              defer {
+                _registrar.endAccess()
+              }
+              return _storage.isHappy
+            }
+            set {
+              _registrar.beginAccess(\.isHappy)
+              _registrar.register(observable: self, willSet: \.isHappy, to: newValue)
+              defer {
+                _registrar.register(observable: self, didSet: \.isHappy)
+                _registrar.endAccess()
+              }
+              _storage.isHappy = newValue
+            }
+          }
+
+          init() {}
+
+          func bark() {
+            print("bork bork")
+          }
+
+          let _registrar = ObservationRegistrar<Dog >()
+
+          public nonisolated func addObserver(_ observer: some Observer<Dog >) {
+            _registrar.addObserver(observer)
+          }
+
+          public nonisolated func removeObserver(_ observer: some Observer<Dog >) {
+            _registrar.removeObserver(observer)
+          }
+
+          private func withTransaction<T>(_ apply: () throws -> T) rethrows -> T {
+            _registrar.beginAccess()
+            defer {
+              _registrar.endAccess()
+            }
+            return try apply()
+          }
+
+          private struct Storage {
+
+            var name: String?
+            var treat: Treat?
+
+            var isHappy: Bool = true
+          }
+
+          private var _storage = Storage()
+        }
+
+        extension Dog: Observable {
+        }
+        """#
+      }
+    #else
+      assertMacro {
+        """
+        @Observable
+        final class Dog {
+          var name: String?
+          var treat: Treat?
+
+          var isHappy: Bool = true
+
+          init() {}
+
+          func bark() {
+            print("bork bork")
+          }
+        }
+        """
+      } expansion: {
+        #"""
+        final class Dog {
+          var name: String? {
+            get {
+              _registrar.beginAccess(\.name)
+              defer {
+                _registrar.endAccess()
+              }
+              return _storage.name
+            }
+            set {
+              _registrar.beginAccess(\.name)
+              _registrar.register(observable: self, willSet: \.name, to: newValue)
+              defer {
+                _registrar.register(observable: self, didSet: \.name)
+                _registrar.endAccess()
+              }
+              _storage.name = newValue
+            }
+          }
+          var treat: Treat? {
+            get {
+              _registrar.beginAccess(\.treat)
+              defer {
+                _registrar.endAccess()
+              }
+              return _storage.treat
+            }
+            set {
+              _registrar.beginAccess(\.treat)
+              _registrar.register(observable: self, willSet: \.treat, to: newValue)
+              defer {
+                _registrar.register(observable: self, didSet: \.treat)
+                _registrar.endAccess()
+              }
+              _storage.treat = newValue
+            }
+          }
+
+          var isHappy: Bool {
+            get {
+              _registrar.beginAccess(\.isHappy)
+              defer {
+                _registrar.endAccess()
+              }
+              return _storage.isHappy
+            }
+            set {
+              _registrar.beginAccess(\.isHappy)
+              _registrar.register(observable: self, willSet: \.isHappy, to: newValue)
+              defer {
+                _registrar.register(observable: self, didSet: \.isHappy)
+                _registrar.endAccess()
+              }
+              _storage.isHappy = newValue
+            }
+          }
+
+          init() {}
+
+          func bark() {
+            print("bork bork")
+          }
+
+          let _registrar = ObservationRegistrar<Dog >()
+
+          public nonisolated func addObserver(_ observer: some Observer<Dog >) {
+            _registrar.addObserver(observer)
+          }
+
+          public nonisolated func removeObserver(_ observer: some Observer<Dog >) {
+            _registrar.removeObserver(observer)
+          }
+
+          private func withTransaction<T>(_ apply: () throws -> T) rethrows -> T {
+            _registrar.beginAccess()
+            defer {
+              _registrar.endAccess()
+            }
+            return try apply()
+          }
+
+          private struct Storage {
+
+            var name: String?
+            var treat: Treat?
+
+            var isHappy: Bool = true
+          }
+
+          private var _storage = Storage()
+        }
+
+        extension Dog: Observable {
+        }
+        """#
+      }
+    #endif
+  }
+}

--- a/Tests/MacroTestingTests/OptionSetMacroTests.swift
+++ b/Tests/MacroTestingTests/OptionSetMacroTests.swift
@@ -9,104 +9,205 @@ final class OptionSetMacroTests: BaseTestCase {
   }
 
   func testExpansionOnStructWithNestedEnumAndStatics() {
-    assertMacro {
-      """
-      @MyOptionSet<UInt8>
-      struct ShippingOptions {
-        private enum Options: Int {
-          case nextDay
-          case secondDay
-          case priority
-          case standard
+    #if canImport(SwiftSyntax600)
+      assertMacro {
+        """
+        @MyOptionSet<UInt8>
+        struct ShippingOptions {
+          private enum Options: Int {
+            case nextDay
+            case secondDay
+            case priority
+            case standard
+          }
+
+          static let express: ShippingOptions = [.nextDay, .secondDay]
+          static let all: ShippingOptions = [.express, .priority, .standard]
+        }
+        """
+      } expansion: {
+        """
+        struct ShippingOptions {
+          private enum Options: Int {
+            case nextDay
+            case secondDay
+            case priority
+            case standard
+          }
+
+          static let express: ShippingOptions = [.nextDay, .secondDay]
+          static let all: ShippingOptions = [.express, .priority, .standard]
+
+          typealias RawValue = UInt8
+
+          var rawValue: RawValue
+
+          init() {
+            self.rawValue = 0
+          }
+
+          init(rawValue: RawValue) {
+            self.rawValue = rawValue
+          }
+
+          static let nextDay: Self =
+            Self(rawValue: 1 << Options.nextDay.rawValue)
+
+          static let secondDay: Self =
+            Self(rawValue: 1 << Options.secondDay.rawValue)
+
+          static let priority: Self =
+            Self(rawValue: 1 << Options.priority.rawValue)
+
+          static let standard: Self =
+            Self(rawValue: 1 << Options.standard.rawValue)
         }
 
-        static let express: ShippingOptions = [.nextDay, .secondDay]
-        static let all: ShippingOptions = [.express, .priority, .standard]
+        extension ShippingOptions: OptionSet {
+        }
+        """
       }
-      """
-    } expansion: {
-      """
-      struct ShippingOptions {
-        private enum Options: Int {
-          case nextDay
-          case secondDay
-          case priority
-          case standard
+    #else
+      assertMacro {
+        """
+        @MyOptionSet<UInt8>
+        struct ShippingOptions {
+          private enum Options: Int {
+            case nextDay
+            case secondDay
+            case priority
+            case standard
+          }
+
+          static let express: ShippingOptions = [.nextDay, .secondDay]
+          static let all: ShippingOptions = [.express, .priority, .standard]
+        }
+        """
+      } expansion: {
+        """
+        struct ShippingOptions {
+          private enum Options: Int {
+            case nextDay
+            case secondDay
+            case priority
+            case standard
+          }
+
+          static let express: ShippingOptions = [.nextDay, .secondDay]
+          static let all: ShippingOptions = [.express, .priority, .standard]
+
+          typealias RawValue = UInt8
+
+          var rawValue: RawValue
+
+          init() {
+            self.rawValue = 0
+          }
+
+          init(rawValue: RawValue) {
+            self.rawValue = rawValue
+          }
+
+          static let nextDay: Self =
+            Self (rawValue: 1 << Options.nextDay.rawValue)
+
+          static let secondDay: Self =
+            Self (rawValue: 1 << Options.secondDay.rawValue)
+
+          static let priority: Self =
+            Self (rawValue: 1 << Options.priority.rawValue)
+
+          static let standard: Self =
+            Self (rawValue: 1 << Options.standard.rawValue)
         }
 
-        static let express: ShippingOptions = [.nextDay, .secondDay]
-        static let all: ShippingOptions = [.express, .priority, .standard]
-
-        typealias RawValue = UInt8
-
-        var rawValue: RawValue
-
-        init() {
-          self.rawValue = 0
+        extension ShippingOptions: OptionSet {
         }
-
-        init(rawValue: RawValue) {
-          self.rawValue = rawValue
-        }
-
-        static let nextDay: Self =
-          Self (rawValue: 1 << Options.nextDay.rawValue)
-
-        static let secondDay: Self =
-          Self (rawValue: 1 << Options.secondDay.rawValue)
-
-        static let priority: Self =
-          Self (rawValue: 1 << Options.priority.rawValue)
-
-        static let standard: Self =
-          Self (rawValue: 1 << Options.standard.rawValue)
+        """
       }
-
-      extension ShippingOptions: OptionSet {
-      }
-      """
-    }
+    #endif
   }
 
   func testExpansionOnPublicStructWithExplicitOptionSetConformance() {
-    assertMacro {
-      """
-      @MyOptionSet<UInt8>
-      public struct ShippingOptions: OptionSet {
-        private enum Options: Int {
-          case nextDay
-          case standard
+    #if canImport(SwiftSyntax600)
+      assertMacro {
+        """
+        @MyOptionSet<UInt8>
+        public struct ShippingOptions: OptionSet {
+          private enum Options: Int {
+            case nextDay
+            case standard
+          }
         }
+        """
+      } expansion: {
+        """
+        public struct ShippingOptions: OptionSet {
+          private enum Options: Int {
+            case nextDay
+            case standard
+          }
+
+          public typealias RawValue = UInt8
+
+          public var rawValue: RawValue
+
+          public init() {
+            self.rawValue = 0
+          }
+
+          public init(rawValue: RawValue) {
+            self.rawValue = rawValue
+          }
+
+          public  static let nextDay: Self =
+            Self(rawValue: 1 << Options.nextDay.rawValue)
+
+          public  static let standard: Self =
+            Self(rawValue: 1 << Options.standard.rawValue)
+        }
+        """
       }
-      """
-    } expansion: {
-      """
-      public struct ShippingOptions: OptionSet {
-        private enum Options: Int {
-          case nextDay
-          case standard
+    #else
+      assertMacro {
+        """
+        @MyOptionSet<UInt8>
+        public struct ShippingOptions: OptionSet {
+          private enum Options: Int {
+            case nextDay
+            case standard
+          }
         }
+        """
+      } expansion: {
+        """
+        public struct ShippingOptions: OptionSet {
+          private enum Options: Int {
+            case nextDay
+            case standard
+          }
 
-        public typealias RawValue = UInt8
+          public typealias RawValue = UInt8
 
-        public var rawValue: RawValue
+          public var rawValue: RawValue
 
-        public init() {
-          self.rawValue = 0
+          public init() {
+            self.rawValue = 0
+          }
+
+          public init(rawValue: RawValue) {
+            self.rawValue = rawValue
+          }
+
+          public  static let nextDay: Self =
+            Self (rawValue: 1 << Options.nextDay.rawValue)
+
+          public  static let standard: Self =
+            Self (rawValue: 1 << Options.standard.rawValue)
         }
-
-        public init(rawValue: RawValue) {
-          self.rawValue = rawValue
-        }
-
-        public  static let nextDay: Self =
-          Self (rawValue: 1 << Options.nextDay.rawValue)
-
-        public  static let standard: Self =
-          Self (rawValue: 1 << Options.standard.rawValue)
+        """
       }
-      """
-    }
+    #endif
   }
 
   func testExpansionFailsOnEnumType() {

--- a/Tests/MacroTestingTests/SwiftTestingTests.swift
+++ b/Tests/MacroTestingTests/SwiftTestingTests.swift
@@ -1,0 +1,55 @@
+#if canImport(Testing)
+  @_spi(Experimental) import MacroTesting
+  import Testing
+
+  @Suite(
+    .macros(
+      //record: .failed,
+      macros: ["URL": URLMacro.self]
+    )
+  )
+  struct URLMacroSwiftTestingTests {
+    @Test
+    func expansionWithMalformedURLEmitsError() {
+      assertMacro {
+        """
+        let invalid = #URL("https://not a url.com")
+        """
+      } diagnostics: {
+        """
+        let invalid = #URL("https://not a url.com")
+                      ┬────────────────────────────
+                      ╰─ 🛑 malformed url: "https://not a url.com"
+        """
+      }
+    }
+
+    @Test
+    func expansionWithStringInterpolationEmitsError() {
+      assertMacro {
+        #"""
+        #URL("https://\(domain)/api/path")
+        """#
+      } diagnostics: {
+        #"""
+        #URL("https://\(domain)/api/path")
+        ┬─────────────────────────────────
+        ╰─ 🛑 #URL requires a static string literal
+        """#
+      }
+    }
+
+    @Test
+    func expansionWithValidURL() {
+      assertMacro {
+        """
+        let valid = #URL("https://swift.org/")
+        """
+      } expansion: {
+        """
+        let valid = URL(string: "https://swift.org/")!
+        """
+      }
+    }
+  }
+#endif

--- a/Tests/MemberwiseInitTests/MemberwiseInitInferredTypeTests.swift
+++ b/Tests/MemberwiseInitTests/MemberwiseInitInferredTypeTests.swift
@@ -306,7 +306,9 @@ final class MemberwiseInitInferredTypeTests: XCTestCase {
   func testVarPropertyWithInitializerAs() {
     assertMacro {
       """
-      enum T { case foo }
+      enum T {
+        case foo
+      }
       @MemberwiseInit
       public struct S {
         var value = .foo as T
@@ -314,7 +316,9 @@ final class MemberwiseInitInferredTypeTests: XCTestCase {
       """
     } expansion: {
       """
-      enum T { case foo }
+      enum T {
+        case foo
+      }
       public struct S {
         var value = .foo as T
 
@@ -513,26 +517,49 @@ final class MemberwiseInitInferredTypeTests: XCTestCase {
   // NB: Xcode and SwiftSyntax prefer `[T] ()`, but swift-format prefers `[T]()`.
   // The node is copied unchanged from the property declaration and SwiftSyntax is adding trivia.
   func testArrayWithExplicitTypeInitializer() {
-    assertMacro {
-      ##"""
-      @MemberwiseInit
-      public struct S {
-        var array = [String]()
-      }
-      """##
-    } expansion: {
-      """
-      public struct S {
-        var array = [String]()
-
-        internal init(
-          array: [String] = [String] ()
-        ) {
-          self.array = array
+    #if canImport(SwiftSyntax600)
+      assertMacro {
+        ##"""
+        @MemberwiseInit
+        public struct S {
+          var array = [String]()
         }
+        """##
+      } expansion: {
+        """
+        public struct S {
+          var array = [String]()
+
+          internal init(
+            array: [String] = [String]()
+          ) {
+            self.array = array
+          }
+        }
+        """
       }
-      """
-    }
+    #else
+      assertMacro {
+        ##"""
+        @MemberwiseInit
+        public struct S {
+          var array = [String]()
+        }
+        """##
+      } expansion: {
+        """
+        public struct S {
+          var array = [String]()
+
+          internal init(
+            array: [String] = [String] ()
+          ) {
+            self.array = array
+          }
+        }
+        """
+      }
+    #endif
   }
 
   // FIXME: Diagnostic is excessive on already invalid syntax, but we can only detect special cases.
@@ -761,26 +788,49 @@ final class MemberwiseInitInferredTypeTests: XCTestCase {
   // The node is copied unchanged from the property declaration and SwiftSyntax is adding trivia.
   // I tried detaching the syntax node, to no effect.
   func testDictionaryWithExplicitTypeInitializer() {
-    assertMacro {
-      ##"""
-      @MemberwiseInit
-      public struct S {
-        var dictionary = [String: Int]()
-      }
-      """##
-    } expansion: {
-      """
-      public struct S {
-        var dictionary = [String: Int]()
-
-        internal init(
-          dictionary: [String: Int] = [String: Int] ()
-        ) {
-          self.dictionary = dictionary
+    #if canImport(SwiftSyntax600)
+      assertMacro {
+        ##"""
+        @MemberwiseInit
+        public struct S {
+          var dictionary = [String: Int]()
         }
+        """##
+      } expansion: {
+        """
+        public struct S {
+          var dictionary = [String: Int]()
+
+          internal init(
+            dictionary: [String: Int] = [String: Int]()
+          ) {
+            self.dictionary = dictionary
+          }
+        }
+        """
       }
-      """
-    }
+    #else
+      assertMacro {
+        ##"""
+        @MemberwiseInit
+        public struct S {
+          var dictionary = [String: Int]()
+        }
+        """##
+      } expansion: {
+        """
+        public struct S {
+          var dictionary = [String: Int]()
+
+          internal init(
+            dictionary: [String: Int] = [String: Int] ()
+          ) {
+            self.dictionary = dictionary
+          }
+        }
+        """
+      }
+    #endif
   }
 
   // FIXME: Diagnostic is excessive on already invalid syntax.

--- a/Tests/MemberwiseInitTests/MemberwiseInitTests.swift
+++ b/Tests/MemberwiseInitTests/MemberwiseInitTests.swift
@@ -869,67 +869,133 @@ final class MemberwiseInitTests: XCTestCase {
   }
 
   func testInitAndInit_FailsWithDiagnostic() {
-    assertMacro {
-      """
-      @MemberwiseInit
-      struct S {
-        @Init @Init
-        let value: T
-      }
-      """
-    } expansion: {
-      """
-      struct S {
-        let value: T
-
-        internal init() {
+    #if canImport(SwiftSyntax600)
+      assertMacro {
+        """
+        @MemberwiseInit
+        struct S {
+          @Init @Init
+          let value: T
         }
+        """
+      } expansion: {
+        """
+        struct S {
+
+          let value: T
+
+          internal init() {
+          }
+        }
+        """
+      } diagnostics: {
+        """
+        @MemberwiseInit
+        struct S {
+          @Init @Init
+                ┬────
+                ╰─ 🛑 Multiple @Init configurations are not supported by @MemberwiseInit
+          let value: T
+        }
+        """
       }
-      """
-    } diagnostics: {
-      """
-      @MemberwiseInit
-      struct S {
-        @Init @Init
-              ┬────
-              ╰─ 🛑 Multiple @Init configurations are not supported by @MemberwiseInit
-        let value: T
+    #else
+      assertMacro {
+        """
+        @MemberwiseInit
+        struct S {
+          @Init @Init
+          let value: T
+        }
+        """
+      } expansion: {
+        """
+        struct S {
+          let value: T
+
+          internal init() {
+          }
+        }
+        """
+      } diagnostics: {
+        """
+        @MemberwiseInit
+        struct S {
+          @Init @Init
+                ┬────
+                ╰─ 🛑 Multiple @Init configurations are not supported by @MemberwiseInit
+          let value: T
+        }
+        """
       }
-      """
-    }
+    #endif
   }
 
   func testInitInitWrapperInitRaw_FailsWithDiagnostics() {
-    assertMacro {
-      """
-      @MemberwiseInit
-      struct S {
-        @Init @InitWrapper @InitRaw
-        let value: T
-      }
-      """
-    } expansion: {
-      """
-      struct S {@InitWrapper @InitRaw
-        let value: T
-
-        internal init() {
+    #if canImport(SwiftSyntax600)
+      assertMacro {
+        """
+        @MemberwiseInit
+        struct S {
+          @Init @InitWrapper @InitRaw
+          let value: T
         }
+        """
+      } expansion: {
+        """
+        struct S {
+          @InitWrapper @InitRaw
+          let value: T
+
+          internal init() {
+          }
+        }
+        """
+      } diagnostics: {
+        """
+        @MemberwiseInit
+        struct S {
+          @Init @InitWrapper @InitRaw
+                             ┬───────
+                │            ╰─ 🛑 Multiple @Init configurations are not supported by @MemberwiseInit
+                ┬───────────
+                ╰─ 🛑 Multiple @Init configurations are not supported by @MemberwiseInit
+          let value: T
+        }
+        """
       }
-      """
-    } diagnostics: {
-      """
-      @MemberwiseInit
-      struct S {
-        @Init @InitWrapper @InitRaw
-                           ┬───────
-              │            ╰─ 🛑 Multiple @Init configurations are not supported by @MemberwiseInit
-              ┬───────────
-              ╰─ 🛑 Multiple @Init configurations are not supported by @MemberwiseInit
-        let value: T
+    #else
+      assertMacro {
+        """
+        @MemberwiseInit
+        struct S {
+          @Init @InitWrapper @InitRaw
+          let value: T
+        }
+        """
+      } expansion: {
+        """
+        struct S {@InitWrapper @InitRaw
+          let value: T
+
+          internal init() {
+          }
+        }
+        """
+      } diagnostics: {
+        """
+        @MemberwiseInit
+        struct S {
+          @Init @InitWrapper @InitRaw
+                             ┬───────
+                │            ╰─ 🛑 Multiple @Init configurations are not supported by @MemberwiseInit
+                ┬───────────
+                ╰─ 🛑 Multiple @Init configurations are not supported by @MemberwiseInit
+          let value: T
+        }
+        """
       }
-      """
-    }
+    #endif
   }
 
   // MARK: - Test invalid syntax

--- a/Tests/MemberwiseInitTests/ReadmeTests.swift
+++ b/Tests/MemberwiseInitTests/ReadmeTests.swift
@@ -82,31 +82,55 @@ final class ReadmeTests: XCTestCase {
     }
   }
 
-  // FIXME: What's causing bad formatting of the expansion? swift-syntax 5.10 related?
   func testIgnoreAge() {
-    assertMacro {
-      """
-        @MemberwiseInit(.public)
-        public struct Person {
-          public let name: String
-          @Init(.ignore) private var age: Int? = nil
-        }
-      """
-    } expansion: {
-      """
-        
-        public struct Person {
-          public let name: String
-          private var age: Int? = nil
+    #if canImport(SwiftSyntax600)
+      assertMacro {
+        """
+          @MemberwiseInit(.public)
+          public struct Person {
+            public let name: String
+            @Init(.ignore) private var age: Int? = nil
+          }
+        """
+      } expansion: {
+        """
+          public struct Person {
+            public let name: String
+            private var age: Int? = nil
 
-        public init(
-          name: String
-        ) {
-          self.name = name
-        }
-        }
-      """
-    }
+            public init(
+              name: String
+            ) {
+              self.name = name
+            }
+          }
+        """
+      }
+    #else
+      assertMacro {
+        """
+          @MemberwiseInit(.public)
+          public struct Person {
+            public let name: String
+            @Init(.ignore) private var age: Int? = nil
+          }
+        """
+      } expansion: {
+        """
+          
+          public struct Person {
+            public let name: String
+            private var age: Int? = nil
+
+          public init(
+            name: String
+          ) {
+            self.name = name
+          }
+          }
+        """
+      }
+    #endif
   }
 
   func testExposeAgePublically() {
@@ -365,32 +389,61 @@ final class ReadmeTests: XCTestCase {
       """
     }
 
-    assertMacro {
-      """
-      import SwiftUI
-      @MemberwiseInit(.internal)
-      struct MyView: View {
-        @Init @State var isOn: Bool  // 👈 `@Init`
+    #if canImport(SwiftSyntax600)
+      assertMacro {
+        """
+        import SwiftUI
+        @MemberwiseInit(.internal)
+        struct MyView: View {
+          @Init @State var isOn: Bool  // 👈 `@Init`
 
-        var body: some View { EmptyView() }
-      }
-      """
-    } expansion: {
-      """
-      import SwiftUI
-      struct MyView: View {@State 
-        var isOn: Bool  // 👈 `@Init`
-
-        var body: some View { EmptyView() }
-
-        internal init(
-          isOn: Bool
-        ) {
-          self.isOn = isOn
+          var body: some View { EmptyView() }
         }
+        """
+      } expansion: {
+        """
+        import SwiftUI
+        struct MyView: View {
+          @State var isOn: Bool  // 👈 `@Init`
+
+          var body: some View { EmptyView() }
+
+          internal init(
+            isOn: Bool
+          ) {
+            self.isOn = isOn
+          }
+        }
+        """
       }
-      """
-    }
+    #else
+      assertMacro {
+        """
+        import SwiftUI
+        @MemberwiseInit(.internal)
+        struct MyView: View {
+          @Init @State var isOn: Bool  // 👈 `@Init`
+
+          var body: some View { EmptyView() }
+        }
+        """
+      } expansion: {
+        """
+        import SwiftUI
+        struct MyView: View {@State 
+          var isOn: Bool  // 👈 `@Init`
+
+          var body: some View { EmptyView() }
+
+          internal init(
+            isOn: Bool
+          ) {
+            self.isOn = isOn
+          }
+        }
+        """
+      }
+    #endif
   }
 
   func testSupportForPropertyWrappers() {


### PR DESCRIPTION
### Support swift-syntax from 600.0.0-latest
- Update SwiftSyntax version range to include 600.0.0-latest
- Add Makefile task to test multiple SwiftSyntax versions
- Update CI workflow to also test against SwiftSyntax 600.0.0-latest
### Update MacroTesting example tests
- Incorporate ObservableMacro and related tests
- Add DefaultFatalErrorImplementationMacro and tests
- Introduce SwiftTestingTests to test Swift Testing, Swift's new native
  testing framework
- Update existing macro examples for compatibility
### Add AttributeRemover600 and conditional usage
- AttributeRemover600 is vendored from SwiftSyntax
- Conditionally use AttributeRemover600 or AttributeRemover509
