### PR TITLE
Update `github/apple` org to `swiftlang`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,11 +24,11 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.1"),
-    //.conditionalPackage(url: "https://github.com/apple/swift-syntax", envVar: "SWIFT_SYNTAX_VERSION", default: "509.0.0..<510.0.0")
-    //.conditionalPackage(url: "https://github.com/apple/swift-syntax", envVar: "SWIFT_SYNTAX_VERSION", default: "510.0.0..<511.0.0")
-    //.conditionalPackage(url: "https://github.com/apple/swift-syntax", envVar: "SWIFT_SYNTAX_VERSION", default: "511.0.0..<601.0.0-prerelease")
+    //.conditionalPackage(url: "https://github.com/swiftlang/swift-syntax", envVar: "SWIFT_SYNTAX_VERSION", default: "509.0.0..<510.0.0")
+    //.conditionalPackage(url: "https://github.com/swiftlang/swift-syntax", envVar: "SWIFT_SYNTAX_VERSION", default: "510.0.0..<511.0.0")
+    //.conditionalPackage(url: "https://github.com/swiftlang/swift-syntax", envVar: "SWIFT_SYNTAX_VERSION", default: "511.0.0..<601.0.0-prerelease")
     .conditionalPackage(
-      url: "https://github.com/apple/swift-syntax",
+      url: "https://github.com/swiftlang/swift-syntax",
       envVar: "SWIFT_SYNTAX_VERSION",
       default: "509.0.0..<601.0.0-prerelease"
     ),


### PR DESCRIPTION
Got some warnings in Xcode about this when using with other dependencies that were already pointing to the new location. I _believe_ this should be a safe change since it's fully migrated to the new org. 

(Really there should probably be some way to indicate that it's an identical package but that's not in our control unfortunately :p)