### PR TITLE
Give `MemberwiseInit` support for `@inlinable` and `@usableFromInline` 

### DIFF
--- a/Sources/MemberwiseInit/MemberwiseInit.swift
+++ b/Sources/MemberwiseInit/MemberwiseInit.swift
@@ -7,11 +7,17 @@ public enum AccessLevelConfig {
   case `open`
 }
 
+public enum InlinabilityConfig {
+  case usableFromInline
+  case inlinable
+}
+
 // MARK: @MemberwiseInit macro
 
 @attached(member, names: named(init))
 public macro MemberwiseInit(
   _ accessLevel: AccessLevelConfig,
+  _ inlinability: InlinabilityConfig? = nil,
   _deunderscoreParameters: Bool? = nil,
   _optionalsDefaultNil: Bool? = nil
 ) =
@@ -22,6 +28,7 @@ public macro MemberwiseInit(
 
 @attached(member, names: named(init))
 public macro MemberwiseInit(
+  _ inlinability: InlinabilityConfig? = nil,
   _deunderscoreParameters: Bool? = nil,
   _optionalsDefaultNil: Bool? = nil
 ) =
@@ -32,6 +39,7 @@ public macro MemberwiseInit(
 
 @attached(member, names: named(init))
 public macro _UncheckedMemberwiseInit(
+  _ inlinability: InlinabilityConfig? = nil,
   _deunderscoreParameters: Bool? = nil,
   _optionalsDefaultNil: Bool? = nil
 ) =
@@ -43,6 +51,7 @@ public macro _UncheckedMemberwiseInit(
 @attached(member, names: named(init))
 public macro _UncheckedMemberwiseInit(
   _ accessLevel: AccessLevelConfig,
+  _ inlinability: InlinabilityConfig? = nil,
   _deunderscoreParameters: Bool? = nil,
   _optionalsDefaultNil: Bool? = nil
 ) =

--- a/Sources/MemberwiseInitClient/main.swift
+++ b/Sources/MemberwiseInitClient/main.swift
@@ -122,6 +122,43 @@ public struct InferType<T: CaseIterable> {
   var dictionaryAs = ["foo": 1, 3: "bar"] as [AnyHashable: Any]
 }
 
+@MemberwiseInit(.inlinable)
+public struct InlinableInit_Default {
+  public let foo: String
+  
+  @Init(.ignore)
+  private var ignored: Int = 7
+}
+let _ = InlinableInit_Default(foo: "bar")
+
+@MemberwiseInit(.internal, .inlinable)
+public struct InlinableInit_Internal {
+  public let foo: String
+  
+  @Init(.ignore)
+  private var ignored: Int = 7
+}
+let _ = InlinableInit_Internal(foo: "bar")
+
+//@MemberwiseInit(.fileprivate, .inlinable)
+//internal struct InlinableInit_FilePrivate {
+//  fileprivate let foo: String
+//  
+//  @Init(.ignore)
+//  private var ignored: Int = 7
+//}
+////let _ = InlinableInit_FilePrivate(foo: "bar")
+
+@MemberwiseInit(.package, .usableFromInline)
+public struct InlinableInit_Package {
+  public let foo: String
+  
+  @Init(.ignore)
+  private var ignored: Int = 7
+}
+let _ = InlinableInit_Package(foo: "bar")
+
+
 // - MARK: Usage tour
 
 public typealias SimpleClosure = () -> Void

--- a/Sources/MemberwiseInitMacros/Macros/MemberwiseInitMacro.swift
+++ b/Sources/MemberwiseInitMacros/Macros/MemberwiseInitMacro.swift
@@ -2,8 +2,9 @@ import SwiftCompilerPlugin
 import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxBuilder
-import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
+
+
 
 public struct InitMacro: PeerMacro {
   public static func expansion(

--- a/Sources/MemberwiseInitMacros/Macros/Support/DeprecationDiagnostics.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/DeprecationDiagnostics.swift
@@ -1,6 +1,6 @@
 import SwiftDiagnostics
 import SwiftSyntax
-import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
 
 func deprecationDiagnostics(
   node: AttributeSyntax,

--- a/Sources/MemberwiseInitMacros/Macros/Support/Diagnostics.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/Diagnostics.swift
@@ -1,6 +1,6 @@
 import SwiftDiagnostics
 import SwiftSyntax
-import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
 
 // MARK: - Diagnose VariableDeclSyntax
 
@@ -496,8 +496,7 @@ extension VariableDeclSyntax {
       newFirstBinding.typeAnnotation = TypeAnnotationSyntax(
         colon: .colonToken(trailingTrivia: .space),
         type: inferredTypeSyntax
-          ?? MissingTypeSyntax(placeholder: TokenSyntax(stringLiteral: "\u{3C}#Type#\u{3E}"))
-          .as(TypeSyntax.self)!
+          ?? TypeSyntax.self(MissingTypeSyntax(placeholder: TokenSyntax(stringLiteral: "\u{3C}#Type#\u{3E}")))!
       )
       newFirstBinding.pattern = newFirstBinding.pattern.trimmed
     }

--- a/Sources/MemberwiseInitMacros/Macros/Support/Diagnostics.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/Diagnostics.swift
@@ -1,5 +1,6 @@
 import SwiftDiagnostics
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
 // MARK: - Diagnose VariableDeclSyntax
@@ -100,7 +101,8 @@ private func diagnoseMemberModifiers(
     return Diagnostic(
       node: modifier,
       message: MacroExpansionWarningMessage(
-        "@\(attributeName) can't be applied to 'static' members"),
+        "@\(attributeName) can't be applied to 'static' members"
+      ),
       fixIts: [variable.fixItRemoveCustomInit].compactMap { $0 }
     )
   }
@@ -255,10 +257,12 @@ private func diagnoseAccessibilityLeak(
 
     return FixIt(
       message: MacroExpansionFixItMessage(
-        "Add '@\(customAttribute.attributeName.trimmedDescription)(.\(targetAccessLevel))'"),
+        "Add '@\(customAttribute.attributeName.trimmedDescription)(.\(targetAccessLevel))'"
+      ),
       changes: [
         FixIt.Change.replace(
-          oldNode: Syntax(variable), newNode: Syntax(newVariable)
+          oldNode: Syntax(variable),
+          newNode: Syntax(newVariable)
         )
       ]
     )
@@ -314,7 +318,8 @@ private func diagnoseAccessibilityLeak(
       message: MacroExpansionFixItMessage(message),
       changes: [
         FixIt.Change.replace(
-          oldNode: Syntax(variable), newNode: Syntax(newVariable)
+          oldNode: Syntax(variable),
+          newNode: Syntax(newVariable)
         )
       ]
     )
@@ -355,7 +360,8 @@ private func diagnoseAccessibilityLeak(
       message: MacroExpansionFixItMessage(message),
       changes: [
         FixIt.Change.replace(
-          oldNode: Syntax(variable), newNode: Syntax(newVariable)
+          oldNode: Syntax(variable),
+          newNode: Syntax(newVariable)
         )
       ]
     )
@@ -457,7 +463,8 @@ extension VariableDeclSyntax {
       changes: [
         FixIt.Change.replace(
           oldNode: Syntax(customAttribute),
-          newNode: Syntax(newAttribute))
+          newNode: Syntax(newAttribute)
+        )
       ]
     )
   }
@@ -475,7 +482,8 @@ extension VariableDeclSyntax {
       message: MacroExpansionFixItMessage("Remove '\(customAttribute.trimmedDescription)'"),
       changes: [
         FixIt.Change.replace(
-          oldNode: Syntax(self), newNode: Syntax(newVariable)
+          oldNode: Syntax(self),
+          newNode: Syntax(newVariable)
         )
       ]
     )
@@ -496,7 +504,9 @@ extension VariableDeclSyntax {
       newFirstBinding.typeAnnotation = TypeAnnotationSyntax(
         colon: .colonToken(trailingTrivia: .space),
         type: inferredTypeSyntax
-          ?? TypeSyntax.self(MissingTypeSyntax(placeholder: TokenSyntax(stringLiteral: "\u{3C}#Type#\u{3E}")))!
+          ?? TypeSyntax.self(
+            MissingTypeSyntax(placeholder: TokenSyntax(stringLiteral: "\u{3C}#Type#\u{3E}"))
+          )!
       )
       newFirstBinding.pattern = newFirstBinding.pattern.trimmed
     }
@@ -510,7 +520,8 @@ extension VariableDeclSyntax {
       ),
       changes: [
         FixIt.Change.replace(
-          oldNode: Syntax(self), newNode: Syntax(newNode)
+          oldNode: Syntax(self),
+          newNode: Syntax(newNode)
         )
       ]
     )
@@ -537,4 +548,140 @@ extension LabeledExprListSyntax {
       return modifiedSyntaxList
     }
   }
+}
+
+// MARK: - Diagnose AttributeSyntax
+
+extension AttributeSyntax {
+
+  func allInlinabilityFixIts(typeAccessLevel: AccessLevelModifier) -> [FixIt] {
+    // NB: returning nil when empty to be consistent with Diagnostic's choice of default argument value
+    var result: [FixIt] = []
+    if let fixItRemoveInlinability {
+      result.append(fixItRemoveInlinability)
+    }
+    if let fixItReplaceUsableFromInlineWithInlinable {
+      result.append(fixItReplaceUsableFromInlineWithInlinable)
+    }
+    if let fixItsMakeAccessLevelCompatibleWithInlinabilityChoice = fixItsMakeAccessLevelCompatibleWithInlinabilityChoice(typeAccessLevel: typeAccessLevel) {
+      result.append(contentsOf: fixItsMakeAccessLevelCompatibleWithInlinabilityChoice)
+    }
+
+    return result
+  }
+
+  var fixItRemoveInlinability: FixIt? {
+    guard
+      let inlinability = firstArgumentValue(
+        interpretableAs: InlinabilityAttribute.self
+      ),
+      case .argumentList(let originalArgumentList) = arguments
+    else {
+      return nil
+    }
+
+    return FixIt(
+      message: MacroExpansionFixItMessage("Remove '.\(inlinability)'."),
+      changes: [
+        .replace(
+          oldNode: Syntax(self),
+          newNode: Syntax(
+            self.with(
+              \.arguments,
+              .argumentList(
+                originalArgumentList.removingFirstArgumentValue(
+                  interpretableAs: InlinabilityAttribute.self
+                )
+              )
+            )
+          )
+        )
+      ]
+    )
+  }
+
+  var fixItReplaceUsableFromInlineWithInlinable: FixIt? {
+    guard
+      let inlinability = firstArgumentValue(
+        interpretableAs: InlinabilityAttribute.self
+      ),
+      inlinability == .usableFromInline,
+      let accessLevel = firstArgumentValue(interpretableAs: AccessLevelModifier.self),
+      [.public, .open].contains(accessLevel),
+      case .argumentList(let originalArgumentList) = arguments
+    else {
+      return nil
+    }
+
+    return FixIt(
+      message: MacroExpansionFixItMessage(
+        "Change '.\(inlinability)' to '.inlinable'."
+      ),
+      changes: [
+        .replace(
+          oldNode: Syntax(self),
+          newNode: Syntax(
+            self.with(
+              \.arguments,
+              .argumentList(
+                originalArgumentList.replacingFirstArgument(
+                  interpretableAs: InlinabilityAttribute.self,
+                  with: LabeledExprSyntax(expression: ExprSyntax(".inlinable"))
+                )
+              )
+            )
+          )
+        )
+      ]
+    )
+  }
+
+  func fixItsMakeAccessLevelCompatibleWithInlinabilityChoice(typeAccessLevel: AccessLevelModifier) -> [FixIt]? {
+    guard
+      let inlinability = firstArgumentValue(interpretableAs: InlinabilityAttribute.self),
+      let originalAccessLevel = firstArgumentValue(
+        interpretableAs: AccessLevelModifier.self
+      ),
+      [.private, .fileprivate].contains(originalAccessLevel),
+      case .argumentList(let originalArgumentList) = arguments
+    else {
+      return nil
+    }
+
+    let accessLevels: [AccessLevelModifier]
+    switch inlinability {
+    case .usableFromInline:
+      accessLevels = [.internal, .package]
+    case .inlinable:
+      accessLevels = [.internal, .package, .public, .open]
+    }
+
+    return accessLevels
+      .lazy
+      .filter { $0 <= typeAccessLevel }
+      .map { accessLevel in
+        FixIt(
+          message: MacroExpansionFixItMessage(
+            "Change '.\(originalAccessLevel)' to '.\(accessLevel)'."
+          ),
+          changes: [
+            .replace(
+              oldNode: Syntax(self),
+              newNode: Syntax(
+                self.with(
+                  \.arguments,
+                  .argumentList(
+                    originalArgumentList.replacingFirstArgument(
+                      interpretableAs: AccessLevelModifier.self,
+                      with: LabeledExprSyntax(expression: ExprSyntax(".\(raw: accessLevel)"))
+                    )
+                  )
+                )
+              )
+            )
+          ]
+        )
+      }
+  }
+
 }

--- a/Sources/MemberwiseInitMacros/Macros/Support/ExprTypeInference.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/ExprTypeInference.swift
@@ -221,8 +221,8 @@ extension ExprSyntax {
     case .infixOperatorExpr:
       guard
         let infixOperatorExpr = self.as(InfixOperatorExprSyntax.self),
-        let lhsType = infixOperatorExpr.leftOperand.as(ExprSyntax.self)?.inferredType,
-        let rhsType = infixOperatorExpr.rightOperand.as(ExprSyntax.self)?.inferredType,
+        let lhsType = ExprSyntax(infixOperatorExpr.leftOperand)?.inferredType,
+        let rhsType = ExprSyntax(infixOperatorExpr.rightOperand)?.inferredType,
         let operation = InfixOperator(rawValue: infixOperatorExpr.operator.trimmedDescription),
         let inferredType = resultTypeOfInfixOperation(
           lhs: lhsType,

--- a/Sources/MemberwiseInitMacros/Macros/Support/InlinabilityAttribute.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/InlinabilityAttribute.swift
@@ -1,0 +1,7 @@
+import SwiftSyntax
+
+enum InlinabilityAttribute: String, Hashable, CaseIterable, Sendable {
+  case usableFromInline
+  case inlinable
+  
+}

--- a/Sources/MemberwiseInitMacros/Macros/Support/MemberwiseInitFormatter.swift
+++ b/Sources/MemberwiseInitMacros/Macros/Support/MemberwiseInitFormatter.swift
@@ -5,6 +5,7 @@ struct MemberwiseInitFormatter {
   static func formatInitializer(
     properties: [MemberProperty],
     accessLevel: AccessLevelModifier,
+    inlinability: InlinabilityAttribute?,
     deunderscoreParameters: Bool,
     optionalsDefaultNil: Bool?
   ) -> InitializerDeclSyntax {
@@ -14,8 +15,19 @@ struct MemberwiseInitFormatter {
       optionalsDefaultNil: optionalsDefaultNil,
       accessLevel: accessLevel
     )
+    
+    var modifierComponents: [String] = []
+    if let inlinability = inlinability {
+      modifierComponents.append("@\(inlinability.rawValue)")
+    }
+    modifierComponents.append("\(accessLevel.rawValue)")
+    let modifiers = modifierComponents.joined(separator: "\n")
+    // goal:
+    //
+    // @inlinable
+    // public foo
 
-    let formattedInitSignature = "\n\(accessLevel) init(\(formattedParameters))"
+    let formattedInitSignature = "\n\(modifiers) init(\(formattedParameters))"
 
     return try! InitializerDeclSyntax(SyntaxNodeString(stringLiteral: formattedInitSignature)) {
       CodeBlockItemListSyntax(

--- a/Sources/MemberwiseInitMacros/Macros/UncheckedMemberwiseInitMacro.swift
+++ b/Sources/MemberwiseInitMacros/Macros/UncheckedMemberwiseInitMacro.swift
@@ -2,7 +2,6 @@ import SwiftCompilerPlugin
 import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxBuilder
-import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
 
 public struct UncheckedMemberwiseInitMacro: MemberMacro {

--- a/Sources/MemberwiseInitMacros/Macros/UncheckedMemberwiseInitMacro.swift
+++ b/Sources/MemberwiseInitMacros/Macros/UncheckedMemberwiseInitMacro.swift
@@ -22,6 +22,8 @@ public struct UncheckedMemberwiseInitMacro: MemberMacro {
 
     let accessLevel =
       MemberwiseInitMacro.extractConfiguredAccessLevel(from: node) ?? .internal
+    let inlinability =
+    MemberwiseInitMacro.extractInlinabilityAttribute(from: node)
     let optionalsDefaultNil: Bool? =
       MemberwiseInitMacro.extractLabeledBoolArgument("_optionalsDefaultNil", from: node)
     let deunderscoreParameters: Bool =
@@ -36,6 +38,7 @@ public struct UncheckedMemberwiseInitMacro: MemberMacro {
         MemberwiseInitFormatter.formatInitializer(
           properties: properties,
           accessLevel: accessLevel,
+          inlinability: inlinability,
           deunderscoreParameters: deunderscoreParameters,
           optionalsDefaultNil: optionalsDefaultNil
         )

--- a/Tests/MacroTestingTests/MacroExamples/AddAsyncMacro.swift
+++ b/Tests/MacroTestingTests/MacroExamples/AddAsyncMacro.swift
@@ -135,7 +135,7 @@ public struct AddAsyncMacro: PeerMacro {
     funcDecl.signature.effectSpecifiers = FunctionEffectSpecifiersSyntax(
       leadingTrivia: .space,
       asyncSpecifier: .keyword(.async),
-      throwsSpecifier: isResultReturn ? .keyword(.throws) : nil
+      throwsClause: isResultReturn ? ThrowsClauseSyntax(throwsSpecifier: .keyword(.throws))  : nil
     )
 
     // add result type


### PR DESCRIPTION
Hi, thanks for making this macro—it solves a recurring problem really thoroughly!

This PR attempts to give `MemberwiseInit` the ability to synthesize initializers that are either `@usableFromInline` or `@inlinable`. This is somewhat of a niche requirement, but *if* you're writing code that uses those attributes *then* you often need to hand-write the memberwise init just to get the attribute applied.

Assuming you're open to incorporating this capability into the package, I had a couple questions.

1. Unit Testing: right now I've hand-verified the macros and fix-its appear to behave as-expected, but haven't setup any formal unit tests yet. Before adding unit tests, I wanted to know if (a) you'd be ok with a smaller number of hand-written checks or (b) you'd need to see something comparable-to/integrated-with your existing test-code-generation strategy? 
2. API Design: I tried to make the changes fit in with the existing style and stay readable at the use site. Let me know if you'd like anything changed.

Other remarks:

- I addressed some deprecation warnings (e.g. some uses of `.as` are now deprecated)
- I added some helper functions to reduce boilerplate
- I ran swift-format once on the Diagnostics.swift file and it changed some existing code I didn't touch—happy to back that out
