### PR TITLE
Bump swift-syntax version range

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
     .conditionalPackage(
       url: "https://github.com/swiftlang/swift-syntax",
       envVar: "SWIFT_SYNTAX_VERSION",
-      default: "509.0.0..<602.0.0"
+      default: "509.0.0..<603.0.0"
     ),
   ],
   targets: [


### PR DESCRIPTION
Your package is resolving Swift Syntax as 600.0.1 in my app. I think something else needs tweaking cause I'd expect it to be 602 (or 601 at least).